### PR TITLE
Fix some package.json publish warnings from npm

### DIFF
--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -9,14 +9,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/edgedb/edgedb-js.git"
+    "url": "git+https://github.com/edgedb/edgedb-js.git"
   },
   "license": "Apache-2.0",
   "sideEffects": false,
   "files": [
     "/dist"
   ],
-  "bin": "dist/cli.js",
+  "bin": {
+    "codemod": "dist/cli.js"
+  },
   "peerDependencies": {},
   "devDependencies": {
     "@types/debug": "^4.1.12",

--- a/packages/codemod/tsconfig.json
+++ b/packages/codemod/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "module": "commonjs",
-    "moduleResolution": "node",
-    "skipLibCheck": true,
-    "isolatedModules": false
+    "moduleResolution": "node"
   },
   "include": [
     "transforms/**/*",


### PR DESCRIPTION
npm printed the following warnings when publishing:

npm warn publish npm auto-corrected some errors in your package.json
when publishing. Please run "npm pkg fix" to address these errors.

npm warn publish errors corrected:
npm warn publish "bin" was converted to an object
npm warn publish "bin[@gel/codemod]" was renamed to "bin[codemod]"
npm warn publish "bin[codemod]" script name was cleaned
npm warn publish "repository.url" was normalized to "git+https://github.com/edgedb/edgedb-js.git"