### PR TITLE
Update auth-sveltekit dependency and redirect status

### DIFF
--- a/packages/auth-sveltekit/readme.md
+++ b/packages/auth-sveltekit/readme.md
@@ -70,7 +70,7 @@ You can now access the server auth in all actions and load functions through `ev
 // src/hooks.server.ts
 import serverAuth, {
   type AuthRouteHandlers,
-} from "@edgedb/auth-sveltekit/server";
+} from "@gel/auth-sveltekit/server";
 import { redirect, type Handle } from "@sveltejs/kit";
 import { sequence } from "@sveltejs/kit/hooks";
 import { client } from "$lib/server/auth";
@@ -94,7 +94,7 @@ const authRouteHandlers: AuthRouteHandlers = {
     redirect(303, "/");
   },
   onSignout() {
-    redirect("/");
+    redirect(303, "/");
   },
 };
 


### PR DESCRIPTION
Updated the documentation for auth-sveltekit to use.
@edgedb/auth-sveltekit to 
@gel/auth-sveltekit

And sveltekit's redirect function needs two arguments.