### PR TITLE
Use correct package ranges in create recipes

### DIFF
--- a/packages/create/src/recipes/express/index.ts
+++ b/packages/create/src/recipes/express/index.ts
@@ -30,7 +30,7 @@ const recipe: Recipe = {
         typecheck: "tsc --noEmit",
       },
       dependencies: {
-        ...(baseOptions.useGelAuth ? { "@gel/auth-express": "^0.1.0" } : {}),
+        ...(baseOptions.useGelAuth ? { "@gel/auth-express": "^0.3.0" } : {}),
         "cookie-parser": "^1.4.6",
         express: "^4.18.2",
       },

--- a/packages/create/src/recipes/nextjs/index.ts
+++ b/packages/create/src/recipes/nextjs/index.ts
@@ -97,7 +97,7 @@ const recipe: Recipe<NextjsOptions> = {
         lint: "next lint",
       },
       dependencies: {
-        ...(useGelAuth ? { "@gel/auth-nextjs": "^0.1.0" } : {}),
+        ...(useGelAuth ? { "@gel/auth-nextjs": "^0.4.0" } : {}),
         gel: "^2.0.0",
         react: "^19.0.0",
         "react-dom": "^19.0.0",

--- a/packages/create/src/recipes/remix/index.ts
+++ b/packages/create/src/recipes/remix/index.ts
@@ -37,7 +37,7 @@ const recipe: Recipe = {
         typecheck: "tsc",
       },
       dependencies: {
-        ...(useGelAuth ? { "@gel/auth-remix": "^0.1.0" } : {}),
+        ...(useGelAuth ? { "@gel/auth-remix": "^0.3.0" } : {}),
         react: "^18",
         "react-dom": "^18",
         "@remix-run/css-bundle": "*",

--- a/packages/create/src/recipes/sveltekit/index.ts
+++ b/packages/create/src/recipes/sveltekit/index.ts
@@ -79,7 +79,7 @@ const recipe: Recipe<SveltekitOptions> = {
       },
       dependencies: {
         ...(useGelAuth && {
-          "@gel/auth-sveltekit": "^0.1.1",
+          "@gel/auth-sveltekit": "^0.3.0",
         }),
       },
       devDependencies: {


### PR DESCRIPTION
We should consider using a more robust way of managing these ranges to avoid needing to always touch these directly, while also avoiding making them roughly "*".

This only "broke" because we don't have these old versions published and `^` for 0.x versions won't automatically install the latest minor version since that's considered a breaking change.