### PR TITLE
Updated pkce cookie with new default name

### DIFF
--- a/packages/auth-express/src/index.ts
+++ b/packages/auth-express/src/index.ts
@@ -121,13 +121,13 @@ export class ExpressAuth {
   private getVerifier(cookies: Record<string, string>) {
     return (
       cookies[this.options.pkceVerifierCookieName] ||
-      cookies["edgedb-pkce-verifier"]
+      cookies["gel-pkce-verifier"]
     );
   }
 
   private clearVerifierCookie(res: ExpressResponse) {
     res.clearCookie(this.options.pkceVerifierCookieName);
-    res.clearCookie("edgedb-pkce-verifier");
+    res.clearCookie("gel-pkce-verifier");
   }
 
   private clearAuthCookie(res: ExpressResponse) {

--- a/packages/auth-nextjs/src/app/index.ts
+++ b/packages/auth-nextjs/src/app/index.ts
@@ -104,7 +104,7 @@ export class NextAppAuth extends NextAuth {
         const cookieStore = await cookies();
         const verifier =
           cookieStore.get(this.options.pkceVerifierCookieName)?.value ||
-          cookieStore.get("edgedb-pkce-verifier")?.value;
+          cookieStore.get("gel-pkce-verifier")?.value;
         if (!verifier) {
           throw new PKCEError("no pkce verifier cookie found");
         }

--- a/packages/auth-nextjs/src/shared.ts
+++ b/packages/auth-nextjs/src/shared.ts
@@ -142,7 +142,7 @@ export abstract class NextAuth extends NextAuthHelpers {
   async deleteVerifierCookie() {
     const cookieStore = await cookies();
     cookieStore.delete(this.options.pkceVerifierCookieName);
-    cookieStore.delete("edgedb-pkce-verifier");
+    cookieStore.delete("gel-pkce-verifier");
   }
 
   async deleteAuthCookie() {
@@ -270,7 +270,7 @@ export abstract class NextAuth extends NextAuthHelpers {
       ) => {
         const verifier =
           req.cookies.get(this.options.pkceVerifierCookieName)?.value ||
-          req.cookies.get("edgedb-pkce-verifier")?.value;
+          req.cookies.get("gel-pkce-verifier")?.value;
 
         const params = await ctx.params;
         switch (params.auth.join("/")) {
@@ -744,7 +744,7 @@ export abstract class NextAuth extends NextAuthHelpers {
             try {
               const verifier =
                 req.cookies.get(this.options.pkceVerifierCookieName)?.value ||
-                req.cookies.get("edgedb-pkce-verifier")?.value;
+                req.cookies.get("gel-pkce-verifier")?.value;
               if (!verifier) {
                 throw new PKCEError("no pkce verifier cookie found");
               }

--- a/packages/auth-remix/src/server.ts
+++ b/packages/auth-remix/src/server.ts
@@ -1095,7 +1095,7 @@ export class RemixServerAuth extends RemixClientAuth {
 }
 
 function deleteVerifierCookie(headers: Headers, verifierCookieName: string) {
-  const cookies = [verifierCookieName, "edgedb-pkce-verifier"];
+  const cookies = [verifierCookieName, "gel-pkce-verifier"];
   cookies.forEach((c) =>
     headers.append(
       "Set-Cookie",
@@ -1171,7 +1171,7 @@ function parseCookies(
   return {
     authCookie: parsed[options.authCookieName] || parsed["edgedb-session"],
     pkceVerifierCookie:
-      parsed[options.pkceVerifierCookieName] || parsed["edgedb-pkce-verifier"],
+      parsed[options.pkceVerifierCookieName] || parsed["gel-pkce-verifier"],
   };
 }
 

--- a/packages/auth-sveltekit/src/server.ts
+++ b/packages/auth-sveltekit/src/server.ts
@@ -163,7 +163,7 @@ export class ServerRequestAuth extends ClientAuth {
 
   private deleteVerifierCookie() {
     deleteCookie(this.cookies, this.config.pkceVerifierCookieName);
-    deleteCookie(this.cookies, "edgedb-pkce-verifier");
+    deleteCookie(this.cookies, "gel-pkce-verifier");
   }
 
   private deleteAuthCookie() {
@@ -313,7 +313,7 @@ export class ServerRequestAuth extends ClientAuth {
   ): Promise<{ tokenData: TokenData }> {
     const verifier =
       this.cookies.get(this.config.pkceVerifierCookieName) ||
-      this.cookies.get("edgedb-pkce-verifier");
+      this.cookies.get("gel-pkce-verifier");
 
     if (!verifier) {
       throw new PKCEError("no pkce verifier cookie found");
@@ -494,13 +494,13 @@ async function handleAuthRoutes(
 
   function deleteVerifierCookie() {
     deleteCookie(cookies, config.pkceVerifierCookieName);
-    deleteCookie(cookies, "edgedb-pkce-verifier");
+    deleteCookie(cookies, "gel-pkce-verifier");
   }
 
   function getVerifierCookie() {
     return (
       cookies.get(config.pkceVerifierCookieName) ||
-      cookies.get("edgedb-pkce-verifier")
+      cookies.get("gel-pkce-verifier")
     );
   }
 


### PR DESCRIPTION
fixed the missing occurrences of the PKCE session cookie name.