### PR TITLE
Require explicit index checks or assertions

### DIFF
--- a/integration-tests/lts/tsconfig.json
+++ b/integration-tests/lts/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "@tsconfig/node-lts/tsconfig.json",
-  "compilerOptions": {
-    "noUncheckedIndexedAccess": true
-  },
   "include": ["./**/*.ts"]
 }

--- a/integration-tests/lts/tsconfig.json
+++ b/integration-tests/lts/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@tsconfig/node-lts/tsconfig.json",
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": true
+  },
   "include": ["./**/*.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "eslint": "^9.3.0",
     "prettier": "^3.2.5",
     "turbo": "^2.0.7",
-    "typescript": "^5.5.2",
+    "typescript": "^5.8.2",
     "typescript-eslint": "^8.17.0"
   },
   "scripts": {

--- a/packages/gel/src/reflection/queries/functions.ts
+++ b/packages/gel/src/reflection/queries/functions.ts
@@ -53,16 +53,12 @@ export const functions = async (cxn: Executor) => {
     } filter .internal = false
   `);
 
-  const functionMap = new StrictMap<string, FunctionDef[]>();
+  const functionMap = new StrictMap<string, [FunctionDef, ...FunctionDef[]]>();
 
   const seenFuncDefHashes = new Set<string>();
 
   for (const func of JSON.parse(functionsJson)) {
     const { name } = func;
-    if (!functionMap.has(name)) {
-      functionMap.set(name, []);
-    }
-
     const funcDef: FunctionDef = {
       ...func,
       description: func.annotations[0]?.["@value"],
@@ -73,7 +69,11 @@ export const functions = async (cxn: Executor) => {
     const hash = hashFuncDef(funcDef);
 
     if (!seenFuncDefHashes.has(hash)) {
-      functionMap.get(name).push(funcDef);
+      if (!functionMap.has(name)) {
+        functionMap.set(name, [funcDef]);
+      } else {
+        functionMap.get(name)!.push(funcDef);
+      }
       seenFuncDefHashes.add(hash);
     }
   }

--- a/packages/gel/src/reflection/queries/operators.ts
+++ b/packages/gel/src/reflection/queries/operators.ts
@@ -44,7 +44,7 @@ const _operators = async (cxn: Executor) => {
     } filter not .internal and not .abstract
   `);
 
-  const operators = new StrictMap<string, OperatorDef[]>();
+  const operators = new StrictMap<string, [OperatorDef, ...OperatorDef[]]>();
 
   const seenOpDefHashes = new Set<string>();
 
@@ -60,10 +60,6 @@ const _operators = async (cxn: Executor) => {
     const { mod } = util.splitName(op.name);
 
     const name = `${mod}::${identifier}`;
-
-    if (!operators.has(name)) {
-      operators.set(name, []);
-    }
 
     const opDef: OperatorDef = {
       ...op,
@@ -81,7 +77,11 @@ const _operators = async (cxn: Executor) => {
     const hash = hashOpDef(opDef);
 
     if (!seenOpDefHashes.has(hash)) {
-      operators.get(name).push(opDef);
+      if (!operators.has(name)) {
+        operators.set(name, [opDef]);
+      } else {
+        operators.get(name)!.push(opDef);
+      }
       seenOpDefHashes.add(hash);
     }
   }

--- a/packages/generate/src/cli.ts
+++ b/packages/generate/src/cli.ts
@@ -111,7 +111,7 @@ const run = async () => {
     if (flag.startsWith("--")) {
       if (flag.includes("=")) {
         const [f, ...v] = flag.split("=");
-        flag = f;
+        flag = f!;
         val = v.join("=");
       }
     } else if (flag.startsWith("-")) {
@@ -235,7 +235,7 @@ const run = async () => {
         ) {
           options.file = getVal();
         } else if (generator === Generator.Queries) {
-          if (args.length > 0 && args[0][0] !== "-") {
+          if (args.length > 0 && args[0]![0] !== "-") {
             options.file = getVal();
           } else {
             options.file = path.join(schemaDir, "queries");

--- a/packages/generate/src/edgeql-js/generateCastMaps.ts
+++ b/packages/generate/src/edgeql-js/generateCastMaps.ts
@@ -286,7 +286,7 @@ export const generateCastMaps = (params: GeneratorParams) => {
             !type.enum_values &&
             !type.material_id &&
             !type.cast_type &&
-            !(scalarToLiteralMapping[type.name]?.literalKind)
+            !scalarToLiteralMapping[type.name]?.literalKind
           );
         })
         .map((scalar) => getRef(scalar.name)),

--- a/packages/generate/src/edgeql-js/generateCastMaps.ts
+++ b/packages/generate/src/edgeql-js/generateCastMaps.ts
@@ -286,8 +286,7 @@ export const generateCastMaps = (params: GeneratorParams) => {
             !type.enum_values &&
             !type.material_id &&
             !type.cast_type &&
-            (!scalarToLiteralMapping[type.name] ||
-              !scalarToLiteralMapping[type.name].literalKind)
+            !(scalarToLiteralMapping[type.name]?.literalKind)
           );
         })
         .map((scalar) => getRef(scalar.name)),

--- a/packages/generate/src/edgeql-js/generateFunctionTypes.ts
+++ b/packages/generate/src/edgeql-js/generateFunctionTypes.ts
@@ -75,7 +75,7 @@ export function generateFuncopTypes<F extends FuncopDef>(
   dir: DirBuilder,
   types: $.introspect.Types,
   casts: $.introspect.Casts,
-  funcops: $.StrictMap<string, F[]>,
+  funcops: $.StrictMap<string, [F, ...F[]]>,
   funcopExprKind: string,
   typeDefSuffix: string,
   optionalUndefined: boolean,
@@ -398,7 +398,7 @@ export function generateFuncopTypes<F extends FuncopDef>(
     code.indented(() => {
       code.writeln([
         r`const {${
-          funcDefs[0].kind ? "kind, " : ""
+          funcDefs[0]?.kind ? "kind, " : ""
         }returnType, cardinality, args: positionalArgs, namedArgs} = _.syntax.$resolveOverload('${funcName}', args, _.spec, [`,
       ]);
       code.indented(() => {
@@ -519,8 +519,8 @@ export function getReturnCardinality(
     return {
       type: "MERGE",
       params: [
-        { type: "PARAM", param: params[0].genTypeName },
-        { type: "PARAM", param: params[1].genTypeName },
+        { type: "PARAM", param: params[0]!.genTypeName },
+        { type: "PARAM", param: params[1]!.genTypeName },
       ],
     };
   }
@@ -529,8 +529,8 @@ export function getReturnCardinality(
     return {
       type: "COALESCE",
       params: [
-        { type: "PARAM", param: params[0].genTypeName },
-        { type: "PARAM", param: params[1].genTypeName },
+        { type: "PARAM", param: params[0]!.genTypeName },
+        { type: "PARAM", param: params[1]!.genTypeName },
       ],
     };
   }
@@ -538,16 +538,16 @@ export function getReturnCardinality(
   if (name === "std::distinct") {
     return {
       type: "IDENTITY",
-      param: { type: "PARAM", param: params[0].genTypeName },
+      param: { type: "PARAM", param: params[0]!.genTypeName },
     };
   }
 
   if (name === "std::if_else") {
     return {
       type: "IF_ELSE",
-      condition: { type: "PARAM", param: params[1].genTypeName },
-      trueBranch: { type: "PARAM", param: params[0].genTypeName },
-      falseBranch: { type: "PARAM", param: params[2].genTypeName },
+      condition: { type: "PARAM", param: params[1]!.genTypeName },
+      trueBranch: { type: "PARAM", param: params[0]!.genTypeName },
+      falseBranch: { type: "PARAM", param: params[2]!.genTypeName },
     };
   }
 
@@ -557,7 +557,7 @@ export function getReturnCardinality(
       with: "One",
       param: {
         type: "IDENTITY",
-        param: { type: "PARAM", param: params[0].genTypeName },
+        param: { type: "PARAM", param: params[0]!.genTypeName },
       },
     };
   }
@@ -592,7 +592,7 @@ export function getReturnCardinality(
   const cardinality: ReturnCardinality = paramCardinalities.length
     ? paramCardinalities.length > 1
       ? { type: "MULTIPLY", params: paramCardinalities }
-      : { type: "IDENTITY", param: paramCardinalities[0] }
+      : { type: "IDENTITY", param: paramCardinalities[0]! }
     : { type: "ONE" };
 
   return returnTypemod === "OptionalType" && !preservesOptionality
@@ -663,7 +663,7 @@ function renderCardinality(card: ReturnCardinality): string {
         .reduce(
           (cards, card) =>
             `$.cardutil.multiplyCardinalities<${cards}, ${renderParamCardinality(card)}>`,
-          renderParamCardinality(card.params[0]),
+          renderParamCardinality(card.params[0]!),
         );
     }
     default: {

--- a/packages/generate/src/edgeql-js/generateInterfaces.ts
+++ b/packages/generate/src/edgeql-js/generateInterfaces.ts
@@ -29,7 +29,7 @@ export const generateInterfaces = (params: GenerateInterfacesParams) => {
 
     if (!module) {
       const modParts = mod.split("::");
-      const modName = modParts[modParts.length - 1];
+      const modName = modParts.at(-1)!;
       const parentModName = modParts.slice(0, -1).join("::");
       const parent = parentModName ? getModule(parentModName) : null;
       const internalName = makePlainIdent(modName);

--- a/packages/generate/src/edgeql-js/generateObjectTypes.ts
+++ b/packages/generate/src/edgeql-js/generateObjectTypes.ts
@@ -101,7 +101,7 @@ export const getStringRepresentation: (
       })`,
     };
   } else if (type.kind === "tuple") {
-    const isNamed = type.tuple_elements[0].name !== "0";
+    const isNamed = type.tuple_elements[0]?.name !== "0";
     if (isNamed) {
       const itemsStatic = joinFrags(
         type.tuple_elements.map(
@@ -328,8 +328,8 @@ export const generateObjectTypes = (params: GeneratorParams) => {
     for (const ex of type.exclusives) {
       body.writeln([
         t`  {`,
-        ...Object.keys(ex).map((key) => {
-          const target = types.get(ex[key].target_id);
+        ...Object.entries(ex).map(([key, value]) => {
+          const target = types.get(value.target_id);
           const { staticType } = getStringRepresentation(target, { types });
           const card = `$.Cardinality.One | $.Cardinality.AtMostOne `;
           return t`${key}: {__element__: ${staticType}, __cardinality__: ${card}},`;

--- a/packages/generate/src/edgeql-js/generateOperatorTypes.ts
+++ b/packages/generate/src/edgeql-js/generateOperatorTypes.ts
@@ -605,11 +605,11 @@ export function generateOperators({
       _opDefs.map((opDef) => ({
         return_type: opDef.return_type,
         return_typemod: opDef.return_typemod,
-        params0: opDef.params[0]!.type,
-        params0_typemod: opDef.params[0]!.typemod,
-        params1: opDef.params[1]!.type,
-        params1_typemod: opDef.params[1]!.typemod,
-        params2: opDef.params[2]!.type,
+        params0: opDef.params[0]?.type,
+        params0_typemod: opDef.params[0]?.typemod,
+        params1: opDef.params[1]?.type,
+        params1_typemod: opDef.params[1]?.typemod,
+        params2: opDef.params[2]?.type,
         params2_typemod: opDef.params[2]?.typemod,
       })),
     );

--- a/packages/generate/src/edgeql-js/generateOperatorTypes.ts
+++ b/packages/generate/src/edgeql-js/generateOperatorTypes.ts
@@ -45,7 +45,7 @@ export function generateOperatorFunctions({
       code.writeln([t`${returnType}`]);
     },
     (code, _opName, opDefs) => {
-      code.writeln([r`__name__: ${quote(opDefs[0].originalName)},`]);
+      code.writeln([r`__name__: ${quote(opDefs[0]!.originalName)},`]);
       code.writeln([r`__opkind__: kind,`]);
       code.writeln([r`__args__: positionalArgs,`]);
     },
@@ -254,7 +254,7 @@ function operatorFromOpDef(
     if (opDef.anytypes?.kind === "noncastable") {
       return {
         kind: OperatorKind.Infix,
-        args: frag`infixOperandsBaseType<${typeToCodeFragment(lhs)}>`,
+        args: frag`infixOperandsBaseType<${typeToCodeFragment(lhs!)}>`,
         returnElement: "BASE_TYPE",
         returnCardinality: "COALESCE",
         operatorSymbol,
@@ -264,7 +264,7 @@ function operatorFromOpDef(
     ) {
       return {
         kind: OperatorKind.Infix,
-        args: frag`{ lhs: ${typeToCodeFragment(lhs)}, rhs: ${typeToCodeFragment(rhs)} }`,
+        args: frag`{ lhs: ${typeToCodeFragment(lhs!)}, rhs: ${typeToCodeFragment(rhs!)} }`,
         returnElement: "MERGE",
         returnCardinality: "COALESCE",
         operatorSymbol,
@@ -272,7 +272,7 @@ function operatorFromOpDef(
     } else {
       return {
         kind: OperatorKind.Infix,
-        args: frag`{ lhs: ${typeToCodeFragment(lhs)}, rhs: ${typeToCodeFragment(rhs)} }`,
+        args: frag`{ lhs: ${typeToCodeFragment(lhs!)}, rhs: ${typeToCodeFragment(rhs!)} }`,
         returnElement: "CONTAINER",
         returnCardinality: "COALESCE",
         operatorSymbol,
@@ -287,7 +287,7 @@ function operatorFromOpDef(
     const [operand] = opDef.params.positional;
     const returnCardinality = getReturnCardinality(
       opDef.name,
-      [{ ...operand, genTypeName: "Operand" }],
+      [{ ...operand!, genTypeName: "Operand" }],
       opDef.return_typemod,
       false,
     );
@@ -296,7 +296,7 @@ function operatorFromOpDef(
       // Predicate
       return {
         kind: OperatorKind.Prefix,
-        operand: typeToCodeFragment(operand),
+        operand: typeToCodeFragment(operand!),
         operatorSymbol,
         returnElement: "BOOLEAN",
         returnCardinality:
@@ -309,7 +309,7 @@ function operatorFromOpDef(
       // Homogenous
       return {
         kind: OperatorKind.Prefix,
-        operand: typeToCodeFragment(operand),
+        operand: typeToCodeFragment(operand!),
         operatorSymbol,
         returnElement: "HOMOGENEOUS",
         returnCardinality: "PARAM",
@@ -321,25 +321,25 @@ function operatorFromOpDef(
     const getArgsFromAnytypes = () => {
       if (opDef.anytypes && opDef.anytypes.kind === "noncastable") {
         if (opDef.anytypes.typeObj.kind === "range") {
-          return frag`infixOperandsRangeType<${typeToCodeFragment(lhsType)}>`;
+          return frag`infixOperandsRangeType<${typeToCodeFragment(lhsType!)}>`;
         } else if (opDef.anytypes.typeObj.kind === "multirange") {
-          return frag`infixOperandsMultiRangeType<${typeToCodeFragment(lhsType)}>`;
+          return frag`infixOperandsMultiRangeType<${typeToCodeFragment(lhsType!)}>`;
         } else if (opDef.anytypes.typeObj.kind === "array") {
           return frag`infixOperandsArrayTypeNonArray<${typeToCodeFragment(
-            lhsType,
+            lhsType!,
           )}>`;
         } else if (opDef.anytypes.typeObj.kind === "unknown") {
-          return frag`infixOperandsBaseType<${typeToCodeFragment(lhsType)}>`;
+          return frag`infixOperandsBaseType<${typeToCodeFragment(lhsType!)}>`;
         }
       }
 
-      return frag`{ lhs: ${typeToCodeFragment(lhsType)}; rhs: ${typeToCodeFragment(rhsType)} }`;
+      return frag`{ lhs: ${typeToCodeFragment(lhsType!)}; rhs: ${typeToCodeFragment(rhsType!)} }`;
     };
     const _returnCardinality = getReturnCardinality(
       opDef.name,
       [
-        { ...lhsType, genTypeName: "LHS" },
-        { ...rhsType, genTypeName: "RHS" },
+        { ...lhsType!, genTypeName: "LHS" },
+        { ...rhsType!, genTypeName: "RHS" },
       ],
       opDef.return_typemod,
       false,
@@ -349,16 +349,16 @@ function operatorFromOpDef(
         _returnCardinality.type === "MULTIPLY"
           ? _returnCardinality.params.every((p) => p.type === "OPTIONAL")
             ? "MULTIPLY_OPTIONAL"
-            : _returnCardinality.params[1].type === "ONE"
+            : _returnCardinality.params[1]?.type === "ONE"
               ? "MULTIPLY_ONE"
               : "MULTIPLY"
           : "MULTIPLY";
 
-      if (lhsType.type.kind === "scalar") {
+      if (lhsType?.type.kind === "scalar") {
         // Scalar
         return {
           kind: OperatorKind.Infix,
-          args: frag`{ lhs: ${typeToCodeFragment(lhsType)}, rhs: ${typeToCodeFragment(rhsType)} }`,
+          args: frag`{ lhs: ${typeToCodeFragment(lhsType)}, rhs: ${typeToCodeFragment(rhsType!)} }`,
           operatorSymbol,
           returnElement: "BOOLEAN",
           returnCardinality,
@@ -375,7 +375,7 @@ function operatorFromOpDef(
       }
     }
 
-    if (lhsType.type.kind === "scalar") {
+    if (lhsType?.type.kind === "scalar") {
       // Scalar
       return {
         kind: OperatorKind.Infix,
@@ -471,7 +471,7 @@ function operatorFromOpDef(
     if (anytypeIsBaseType) {
       return {
         kind: OperatorKind.Ternary,
-        args: frag`infixOperandsBaseType<${typeToCodeFragment(lhs)}>`,
+        args: frag`infixOperandsBaseType<${typeToCodeFragment(lhs!)}>`,
         operatorSymbol,
         returnElement: "BASE_TYPE",
       };
@@ -482,7 +482,7 @@ function operatorFromOpDef(
     ) {
       return {
         kind: OperatorKind.Ternary,
-        args: frag`{ lhs: ${typeToCodeFragment(lhs)}, rhs: ${typeToCodeFragment(rhs)} }`,
+        args: frag`{ lhs: ${typeToCodeFragment(lhs!)}, rhs: ${typeToCodeFragment(rhs!)} }`,
         operatorSymbol,
         returnElement: "MERGE",
       };
@@ -490,7 +490,7 @@ function operatorFromOpDef(
 
     return {
       kind: OperatorKind.Ternary,
-      args: frag`{ lhs: ${typeToCodeFragment(lhs)}, rhs: ${typeToCodeFragment(rhs)} }`,
+      args: frag`{ lhs: ${typeToCodeFragment(lhs!)}, rhs: ${typeToCodeFragment(rhs!)} }`,
       operatorSymbol,
       returnElement: "CONTAINER",
     };
@@ -605,11 +605,11 @@ export function generateOperators({
       _opDefs.map((opDef) => ({
         return_type: opDef.return_type,
         return_typemod: opDef.return_typemod,
-        params0: opDef.params[0].type,
-        params0_typemod: opDef.params[0].typemod,
-        params1: opDef.params[1]?.type,
-        params1_typemod: opDef.params[1]?.typemod,
-        params2: opDef.params[2]?.type,
+        params0: opDef.params[0]!.type,
+        params0_typemod: opDef.params[0]!.typemod,
+        params1: opDef.params[1]!.type,
+        params1_typemod: opDef.params[1]!.typemod,
+        params2: opDef.params[2]!.type,
         params2_typemod: opDef.params[2]?.typemod,
       })),
     );
@@ -629,11 +629,11 @@ export function generateOperators({
           : splitName(opDef.originalName).name.toLowerCase();
 
       if (opDef.overloadIndex === overloadIndex) {
-        if (!overloadDefs[opDef.operator_kind][opSymbol]) {
-          overloadDefs[opDef.operator_kind][opSymbol] = [];
+        if (!overloadDefs[opDef.operator_kind]![opSymbol]) {
+          overloadDefs[opDef.operator_kind]![opSymbol] = [];
         }
 
-        overloadDefs[opDef.operator_kind][opSymbol].push(
+        overloadDefs[opDef.operator_kind]![opSymbol]!.push(
           generateFuncopDef(opDef),
         );
 
@@ -1244,10 +1244,10 @@ export function generateOperators({
     for (const opKind of Object.keys(overloadDefs)) {
       code.writeln([r`${opKind}: {`]);
       code.indented(() => {
-        for (const symbol of Object.keys(overloadDefs[opKind])) {
+        for (const symbol of Object.keys(overloadDefs[opKind]!)) {
           code.writeln([r`${quote(symbol)}: [`]);
           code.indented(() => {
-            for (const overloadDef of overloadDefs[opKind][symbol]) {
+            for (const overloadDef of overloadDefs[opKind]![symbol]!) {
               code.writeln([r`${overloadDef},`]);
             }
           });

--- a/packages/generate/src/edgeql-js/generateScalars.ts
+++ b/packages/generate/src/edgeql-js/generateScalars.ts
@@ -196,7 +196,7 @@ export const generateScalars = (params: GeneratorParams) => {
         t`type ${ref}λICastableTo = ${joinFrags(
           [
             ref,
-            ...casts.implicitCastFromMap[type.id].map((typeId) =>
+            ...casts.implicitCastFromMap[type.id]!.map((typeId) =>
               getRef(types.get(typeId).name),
             ),
           ],

--- a/packages/generate/src/funcoputil.ts
+++ b/packages/generate/src/funcoputil.ts
@@ -50,9 +50,9 @@ export function expandFuncopAnytypeOverloads<F extends FuncopDef>(
           anytypes: {
             kind: "noncastable" as const,
             type: [getRef("std::anypoint")],
-            typeObj: anypointParams[0].type,
-            refName: anypointParams[0].typeName,
-            refPath: findPathOfAnytype(anypointParams[0].type.id, types),
+            typeObj: anypointParams[0]!.type,
+            refName: anypointParams[0]!.typeName,
+            refPath: findPathOfAnytype(anypointParams[0]!.type.id, types),
           },
         },
       ];
@@ -67,9 +67,9 @@ export function expandFuncopAnytypeOverloads<F extends FuncopDef>(
           anytypes: {
             kind: "noncastable" as const,
             type: ["$.ObjectType"],
-            typeObj: anyobjectParams[0].type,
-            refName: anyobjectParams[0].typeName,
-            refPath: findPathOfAnytype(anyobjectParams[0].type.id, types),
+            typeObj: anyobjectParams[0]!.type,
+            refName: anyobjectParams[0]!.typeName,
+            refPath: findPathOfAnytype(anyobjectParams[0]!.type.id, types),
           },
         },
       ];
@@ -108,9 +108,9 @@ export function expandFuncopAnytypeOverloads<F extends FuncopDef>(
         anytypes: {
           kind: "noncastable" as const,
           type: [hasArrayType ? "$.NonArrayType" : "$.BaseType"],
-          typeObj: anytypeParams[0].type,
-          refName: anytypeParams[0].typeName,
-          refPath: findPathOfAnytype(anytypeParams[0].type.id, types),
+          typeObj: anytypeParams[0]!.type,
+          refName: anytypeParams[0]!.typeName,
+          refPath: findPathOfAnytype(anytypeParams[0]!.type.id, types),
         },
       };
 
@@ -236,7 +236,7 @@ function _findPathOfAnytype(
       return `["__element__"]${elPath}`;
     }
   } else if (type.kind === "tuple") {
-    const isNamed = type.tuple_elements[0].name !== "0";
+    const isNamed = type.tuple_elements[0]!.name !== "0";
     for (const { name, target_id } of type.tuple_elements) {
       const elPath = _findPathOfAnytype(target_id, types);
       if (elPath) {

--- a/packages/generate/src/genutil.ts
+++ b/packages/generate/src/genutil.ts
@@ -210,7 +210,7 @@ export function toTSScalarType(
       }
 
       if (
-        type.tuple_elements[0].name &&
+        type.tuple_elements[0]?.name &&
         Number.isNaN(parseInt(type.tuple_elements[0].name, 10))
       ) {
         // a named tuple
@@ -353,7 +353,7 @@ export function frag(
 ) {
   const frags: CodeFragment[] = [];
   for (let i = 0; i < strings.length; i++) {
-    frags.push(strings[i]);
+    frags.push(strings[i]!);
     if (exprs[i]) {
       if (Array.isArray(exprs[i])) {
         frags.push(...(exprs[i] as CodeFragment[]));

--- a/packages/generate/src/queries.ts
+++ b/packages/generate/src/queries.ts
@@ -74,10 +74,10 @@ currently supported.`);
             if (!filesByExtension[f.extension]) {
               filesByExtension[f.extension] = f;
             } else {
-              filesByExtension[f.extension].contents += `\n\n` + f.contents;
-              filesByExtension[f.extension].imports = filesByExtension[
+              filesByExtension[f.extension]!.contents += `\n\n` + f.contents;
+              filesByExtension[f.extension]!.imports = filesByExtension[
                 f.extension
-              ].imports.merge(f.imports);
+              ]!.imports.merge(f.imports);
             }
           }
         } catch (err) {
@@ -205,7 +205,7 @@ export function generateFiles(params: {
     );
   }
   const functionName = baseFileName
-    .replace(/-[A-Za-z]/g, (m) => m[1].toUpperCase())
+    .replace(/-[A-Za-z]/g, (m) => m[1]!.toUpperCase())
     .replace(/^[^A-Za-z_]|\W/g, "_");
   const interfaceName =
     functionName.charAt(0).toUpperCase() + functionName.slice(1);

--- a/packages/generate/src/syntax/hydrate.ts
+++ b/packages/generate/src/syntax/hydrate.ts
@@ -111,7 +111,7 @@ function applySpecToAncestors(
 function getCommonPointers(arr: Record<string, any>[]): Record<string, any> {
   if (arr.length === 0) return {};
 
-  const firstObj = arr[0];
+  const firstObj = arr[0]!;
   const commonPointers: Record<string, any> = {};
 
   Object.keys(firstObj).forEach((key) => {

--- a/packages/generate/tsconfig.json
+++ b/packages/generate/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "preserveSymlinks": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": false
   },
   "include": ["**/*.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6297,6 +6297,11 @@ typescript@^5.5.2:
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz"
   integrity sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==
 
+typescript@^5.8.2:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
+  integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
+
 undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"


### PR DESCRIPTION
Many places in the code were using unchecked indexed access, which conflicts with many people's TypeScript configurations. We copy the hydrate.ts module directly into the generated code, so we will now check the rest of the generate package with the same strict configuration.

An alternative approach would be to separate out the code we copy into the query builder into a more strict subset and keep the looser config for our own code, but I think stricter is better anyway.

Most places just got the assertion treatment, but in a few places it was straightforward enough to actually do something more safe.