### PR TITLE
Update WebAuthn flow

### DIFF
--- a/packages/auth-core/src/errors.ts
+++ b/packages/auth-core/src/errors.ts
@@ -143,3 +143,11 @@ export class WebAuthnAuthenticationFailedError extends UserError {
     return "WebAuthnAuthenticationFailed";
   }
 }
+
+/** WebAuthn registration failed. */
+export class WebAuthnRegistrationFailedError extends UserError {
+  get type() {
+    return "WebAuthnRegistrationFailed";
+  }
+}
+

--- a/packages/auth-nextjs/src/shared.ts
+++ b/packages/auth-nextjs/src/shared.ts
@@ -61,7 +61,7 @@ export interface CreateAuthRouteHandlers {
   onWebAuthnSignUp(
     params: ParamsOrError<{ tokenData: TokenData | null }>,
     req: NextRequest,
-  ): Promise<NextResponse<SignupResponse>>;
+  ): Promise<Response>;
   onWebAuthnSignIn(
     params: ParamsOrError<{ tokenData: TokenData }>,
     req: NextRequest,


### PR DESCRIPTION
- Add new error type for failed registration attempt
- Loosen the type of the WebAuthn sign up response. This response type is used by the application, not the library, so it should be any valid response type based on the application's needs.