### PR TITLE
Fix module names that are not valid identifiers

### DIFF
--- a/integration-tests/lts/dbschema/default.esdl
+++ b/integration-tests/lts/dbschema/default.esdl
@@ -217,6 +217,10 @@ module `💯💯💯` {
     using (
       SELECT <default::`🚀🚀🚀`>(`🤞` ++ 'Ł🙀')
     );
+
+  type `🚀` {
+    property `🙀` -> str;
+  }
 };
 
 module extra {
@@ -239,5 +243,11 @@ module User {
       property state -> str;
       property zip -> str;
     }
+  }
+}
+
+module `i.got.dots.doot` {
+  type Test {
+    property a: str;
   }
 }

--- a/integration-tests/lts/dbschema/migrations/00029-m1saaen.edgeql
+++ b/integration-tests/lts/dbschema/migrations/00029-m1saaen.edgeql
@@ -1,0 +1,8 @@
+CREATE MIGRATION m1saaenwdwhe4ww5jy34gkdo2tuigheb4rub5frv4o2y3tnjkbqseq
+    ONTO m1cigpnllpzucl3lckxtsfnozf6zbyagfakqal7ejkc3sd2ocj4efa
+{
+  CREATE MODULE `i.got.dots.doot` IF NOT EXISTS;
+  CREATE TYPE `i.got.dots.doot`::Test {
+      CREATE PROPERTY a: std::str;
+  };
+};

--- a/integration-tests/lts/dbschema/migrations/00030-m14ccrz.edgeql
+++ b/integration-tests/lts/dbschema/migrations/00030-m14ccrz.edgeql
@@ -1,0 +1,7 @@
+CREATE MIGRATION m14ccrzhfjulgoy3mdub7s7cfw5neuoxawxlwos2efvwv2si66mbka
+    ONTO m1saaenwdwhe4ww5jy34gkdo2tuigheb4rub5frv4o2y3tnjkbqseq
+{
+  CREATE TYPE `💯💯💯`::`🚀` {
+      CREATE PROPERTY `🙀`: std::str;
+  };
+};

--- a/integration-tests/lts/objectTypes.test.ts
+++ b/integration-tests/lts/objectTypes.test.ts
@@ -33,6 +33,16 @@ describe("object types", () => {
       e.default.Movie.__element__.__pointers__.characters.exclusive,
       false,
     );
+
+    assert.equal(
+      e["i.got.dots.doot"].Test.__element__.__pointers__["a"].target.__name__,
+      "std::str",
+    );
+
+    assert.equal(
+      e["💯💯💯"]["🚀"].__element__.__pointers__["🙀"].target.__name__,
+      "std::str",
+    );
   });
 
   test("link hydration", () => {

--- a/packages/generate/src/builders.ts
+++ b/packages/generate/src/builders.ts
@@ -630,8 +630,11 @@ export class CodeBuilder {
     let prefix = "";
     if (ref.dir !== this.dir) {
       const namespaceParts = identRef.name.split("::").slice(0, -1);
-      prefix = `_${namespaceParts.join("")}`;
-      const moduleFileName = namespaceParts.at(-1)!;
+      prefix = `_${namespaceParts.map(genutil.makePlainIdent).join("")}`;
+      const moduleFileName = path.posix.basename(
+        ref.dir,
+        path.posix.extname(ref.dir),
+      );
 
       let importPath = path.posix.join(
         path.posix.relative(


### PR DESCRIPTION
This regressed in https://github.com/geldata/gel-js/pull/900 due to not having a good test case. The way to reproduce this issue is to ensure that the module ends up as something that the `schema` module would need to import, and it seems like that requires object types defined in these edge case modules.