### PR TITLE
Fix backwards incompatible change in ai extension

### DIFF
--- a/packages/ai/src/core.ts
+++ b/packages/ai/src/core.ts
@@ -218,15 +218,11 @@ export class RAGClient {
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
-        ...request,
-        input: request.inputs,
-      }),
+      body: JSON.stringify(request),
     });
 
     if (!response.ok) {
-      const bodyText = await response.text();
-      throw new Error(bodyText);
+      await handleResponseError(response);
     }
 
     const data: { data: { embedding: number[] }[] } = await response.json();


### PR DESCRIPTION
The name of this property changed during the development of the ai
extension, and in the latest verison, we dropped support for shadowing
the same value across both names, so this is now an error.

Also use the same error handling code from the RAG querying code.

Closes #1232 