### PR TITLE
Export WarningHandler type / Share options exports with browser index

### DIFF
--- a/packages/gel/src/index.node.ts
+++ b/packages/gel/src/index.node.ts
@@ -34,7 +34,7 @@ export {
   Options,
 } from "./options";
 export { defaultBackoff, logWarnings, throwWarnings } from "./options";
-export type { BackoffFunction } from "./options";
+export type { BackoffFunction, WarningHandler } from "./options";
 
 export * from "./index.shared";
 export * as $ from "./reflection/index";

--- a/packages/gel/src/index.node.ts
+++ b/packages/gel/src/index.node.ts
@@ -25,16 +25,7 @@ import * as systemUtils from "./systemUtils";
 export { systemUtils };
 
 export { RawConnection as _RawConnection } from "./rawConn";
-export type { Executor } from "./ifaces";
 export type { Client, ConnectOptions } from "./baseClient";
-export {
-  IsolationLevel,
-  RetryCondition,
-  RetryOptions,
-  Options,
-} from "./options";
-export { defaultBackoff, logWarnings, throwWarnings } from "./options";
-export type { BackoffFunction, WarningHandler } from "./options";
 
 export * from "./index.shared";
 export * as $ from "./reflection/index";

--- a/packages/gel/src/index.shared.ts
+++ b/packages/gel/src/index.shared.ts
@@ -35,6 +35,17 @@ export { parseWKT } from "./datatypes/wkt";
 
 export type { Executor } from "./ifaces";
 
+export {
+  IsolationLevel,
+  RetryCondition,
+  RetryOptions,
+  Options,
+  defaultBackoff,
+  logWarnings,
+  throwWarnings,
+} from "./options";
+export type { BackoffFunction, WarningHandler } from "./options";
+
 export * from "./errors";
 
 export type { Codecs } from "./codecs/codecs";

--- a/packages/gel/src/options.ts
+++ b/packages/gel/src/options.ts
@@ -45,20 +45,20 @@ export interface SimpleRetryOptions {
 
 export type WarningHandler = (warnings: errors.GelError[]) => void;
 
-export function throwWarnings(warnings: errors.GelError[]) {
+export const throwWarnings: WarningHandler = (warnings) => {
   throw new Error(
     `warnings occurred while running query: ${warnings.map((warn) => warn.message)}`,
     { cause: warnings },
   );
-}
+};
 
-export function logWarnings(warnings: errors.GelError[]) {
+export const logWarnings: WarningHandler = (warnings) => {
   for (const warning of warnings) {
     console.warn(
       new Error(`Gel warning: ${warning.message}`, { cause: warning }),
     );
   }
-}
+};
 
 export class RetryOptions {
   // This type is immutable.


### PR DESCRIPTION
Idk if actually moving the options exports to shared helps the browser index at all. I suspect not, since it's gone this long without. They've probably never been needed at runtime.
Regardless, this feels more correct, and it is saner to reason about too internally IMO.