### PR TITLE
Adjust default warning handlers for DX

### DIFF
--- a/packages/gel/src/options.ts
+++ b/packages/gel/src/options.ts
@@ -46,17 +46,16 @@ export interface SimpleRetryOptions {
 export type WarningHandler = (warnings: errors.GelError[]) => void;
 
 export const throwWarnings: WarningHandler = (warnings) => {
-  throw new AggregateError(
-    warnings,
-    `warnings occurred while running query: ${warnings.map((warn) => warn.message)}`,
-  );
+  throw new AggregateError(warnings, formatWarnings(warnings));
 };
 
 export const logWarnings: WarningHandler = (warnings) => {
-  for (const warning of warnings) {
-    console.warn(new Error(`Gel warning: ${warning.message}`));
-  }
+  const merged = new Error(formatWarnings(warnings));
+  console.warn(Object.assign(merged, { name: "" }));
 };
+
+const formatWarnings = (warnings: errors.GelError[]) =>
+  `warnings occurred while running query:\n${warnings.map((warn) => warn.message).join("\n")}`;
 
 export class RetryOptions {
   // This type is immutable.

--- a/packages/gel/src/options.ts
+++ b/packages/gel/src/options.ts
@@ -48,7 +48,7 @@ export type WarningHandler = (warnings: errors.GelError[]) => void;
 export const throwWarnings: WarningHandler = (warnings) => {
   throw new AggregateError(
     warnings,
-    `Warnings occurred while running query: ${warnings.map((warn) => warn.message)}`,
+    `warnings occurred while running query: ${warnings.map((warn) => warn.message)}`,
   );
 };
 

--- a/packages/gel/src/options.ts
+++ b/packages/gel/src/options.ts
@@ -46,17 +46,15 @@ export interface SimpleRetryOptions {
 export type WarningHandler = (warnings: errors.GelError[]) => void;
 
 export const throwWarnings: WarningHandler = (warnings) => {
-  throw new Error(
-    `warnings occurred while running query: ${warnings.map((warn) => warn.message)}`,
-    { cause: warnings },
+  throw new AggregateError(
+    warnings,
+    `Warnings occurred while running query: ${warnings.map((warn) => warn.message)}`,
   );
 };
 
 export const logWarnings: WarningHandler = (warnings) => {
   for (const warning of warnings) {
-    console.warn(
-      new Error(`Gel warning: ${warning.message}`, { cause: warning }),
-    );
+    console.warn(new Error(`Gel warning: ${warning.message}`));
   }
 };
 

--- a/packages/gel/test/client.test.ts
+++ b/packages/gel/test/client.test.ts
@@ -2216,9 +2216,11 @@ test("warnings handler", async () => {
 
     client = client.withWarningHandler(throwWarnings);
 
-    await expect(client.query("select _warn_on_call();")).rejects.toThrow(
-      /warnings occurred while running query: Test warning please ignore/,
+    const queryRes = client.query("select _warn_on_call();");
+    await expect(queryRes).rejects.toThrow(
+      /warnings occurred while running query/,
     );
+    await expect(queryRes).rejects.toThrow(/Test warning please ignore/);
   } finally {
     await client.close();
   }


### PR DESCRIPTION
It is more idiomatic to merge a list of errors with `AggregateError.errors` rather than `Error.cause`.

For logging, giving the original error to the wrapped one in `cause`, causes the error & stacktrace to be duplicated/nested on the console.