### PR TITLE
Return query warnings from the `rawParse/Execute` methods used by UI

### DIFF
--- a/packages/gel/src/fetchConn.ts
+++ b/packages/gel/src/fetchConn.ts
@@ -19,7 +19,7 @@
 import {
   BaseRawConnection,
   Capabilities,
-  ParseResult,
+  type ParseResult,
   PROTO_VER,
   RESTRICTED_CAPABILITIES,
 } from "./baseConn";
@@ -29,7 +29,7 @@ import type { CodecsRegistry } from "./codecs/registry";
 import type { NormalizedConnectConfig } from "./conUtils";
 import {
   BinaryProtocolError,
-  GelError,
+  type GelError,
   InternalClientError,
   ProtocolError,
 } from "./errors";

--- a/packages/gel/src/fetchConn.ts
+++ b/packages/gel/src/fetchConn.ts
@@ -19,6 +19,7 @@
 import {
   BaseRawConnection,
   Capabilities,
+  ParseResult,
   PROTO_VER,
   RESTRICTED_CAPABILITIES,
 } from "./baseConn";
@@ -28,6 +29,7 @@ import type { CodecsRegistry } from "./codecs/registry";
 import type { NormalizedConnectConfig } from "./conUtils";
 import {
   BinaryProtocolError,
+  GelError,
   InternalClientError,
   ProtocolError,
 } from "./errors";
@@ -212,12 +214,10 @@ export class AdminUIFetchConnection extends BaseFetchConnection {
     state: Options,
     options?: QueryOptions,
     abortSignal?: AbortSignal | null,
-  ): Promise<
-    [ICodec, ICodec, Uint8Array, Uint8Array, ProtocolVersion, number]
-  > {
+  ): Promise<[ProtocolVersion, ...ParseResult]> {
     this.abortSignal = abortSignal ?? null;
 
-    const result = (await this._parse(
+    const result = await this._parse(
       language,
       query,
       OutputFormat.BINARY,
@@ -225,15 +225,8 @@ export class AdminUIFetchConnection extends BaseFetchConnection {
       state,
       STUDIO_CAPABILITIES,
       options,
-    ))!;
-    return [
-      result[1],
-      result[2],
-      result[4]!,
-      result[5]!,
-      this.protocolVersion,
-      result[3],
-    ];
+    );
+    return [this.protocolVersion, ...result];
   }
 
   public async rawExecute(
@@ -245,11 +238,11 @@ export class AdminUIFetchConnection extends BaseFetchConnection {
     inCodec?: ICodec,
     args: QueryArgs = null,
     abortSignal?: AbortSignal | null,
-  ): Promise<Uint8Array> {
+  ): Promise<[Uint8Array, GelError[]]> {
     this.abortSignal = abortSignal ?? null;
 
     const result = new WriteBuffer();
-    await this._executeFlow(
+    const warnings = await this._executeFlow(
       language,
       query,
       args,
@@ -262,7 +255,7 @@ export class AdminUIFetchConnection extends BaseFetchConnection {
       STUDIO_CAPABILITIES,
       options,
     );
-    return result.unwrap();
+    return [result.unwrap(), warnings];
   }
 }
 

--- a/packages/gel/test/client.test.ts
+++ b/packages/gel/test/client.test.ts
@@ -2288,17 +2288,19 @@ if (getAvailableFeatures().has("binary-over-http")) {
     expect(result).toHaveLength(5);
     expect(result[0]["__tname__"]).toBe("schema::Function");
 
-    const parseResult2 = await fetchConn.rawParse(
-      Language.EDGEQL,
-      `select _warn_on_call();`,
-      new Options(),
-      options,
-    );
-    const warnings = parseResult2[7];
-    expect(Array.isArray(warnings)).toBe(true);
-    expect(warnings!.length).toBe(1);
-    expect(warnings![0]).toBeInstanceOf(GelError);
-    expect(warnings![0].message.trim()).toBe("Test warning please ignore");
+    if (getGelVersion().major >= 6) {
+      const parseResult2 = await fetchConn.rawParse(
+        Language.EDGEQL,
+        `select _warn_on_call();`,
+        new Options(),
+        options,
+      );
+      const warnings = parseResult2[7];
+      expect(Array.isArray(warnings)).toBe(true);
+      expect(warnings!.length).toBe(1);
+      expect(warnings![0]).toBeInstanceOf(GelError);
+      expect(warnings![0].message.trim()).toBe("Test warning please ignore");
+    }
   });
 
   test("binary protocol over http failing auth", async () => {


### PR DESCRIPTION
Currently the UI can't show query warnings as `rawParse`/`rawExecute` don't return them. Also just return the whole return values array from the internal `_parse` method in `rawParse` instead of re-ordering it for no real reason.