### PR TITLE
Export `SimpleConfig` via `index.shared.ts`

### DIFF
--- a/packages/gel/src/index.shared.ts
+++ b/packages/gel/src/index.shared.ts
@@ -40,6 +40,7 @@ export {
   RetryCondition,
   RetryOptions,
   Options,
+  SimpleConfig,
   defaultBackoff,
   logWarnings,
   throwWarnings,


### PR DESCRIPTION
Best guess at a fix for https://github.com/geldata/gel-js/issues/1243