### PR TITLE
Expose query capabilities in `client.describe()` and `analyzeQuery`

### DIFF
--- a/packages/gel/src/baseClient.ts
+++ b/packages/gel/src/baseClient.ts
@@ -751,7 +751,7 @@ export class Client implements Executor {
     }
   }
 
-  async parse(query: string) {
+  async describe(query: string) {
     const holder = await this.pool.acquireHolder(this.options);
     try {
       const cxn = await holder._getConnection();
@@ -768,9 +768,17 @@ export class Client implements Executor {
         in: result[1],
         out: result[2],
         cardinality,
+        capabilities: result[3],
       };
     } finally {
       await holder.release();
     }
+  }
+
+  /**
+   * @deprecated Use `describe` instead.
+   */
+  async parse(query: string) {
+    return await this.describe(query);
   }
 }

--- a/packages/gel/src/reflection/analyzeQuery.ts
+++ b/packages/gel/src/reflection/analyzeQuery.ts
@@ -16,6 +16,7 @@ type QueryType = {
   args: string;
   result: string;
   cardinality: Cardinality;
+  capabilities: number;
   query: string;
   importMap: ImportMap;
   /** @deprecated */
@@ -26,7 +27,12 @@ export async function analyzeQuery(
   client: Client,
   query: string,
 ): Promise<QueryType> {
-  const { cardinality, in: inCodec, out: outCodec } = await client.parse(query);
+  const {
+    cardinality,
+    capabilities,
+    in: inCodec,
+    out: outCodec,
+  } = await client.describe(query);
 
   const args = generateTSTypeFromCodec(inCodec, Cardinality.One, {
     optionalNulls: true,
@@ -39,6 +45,7 @@ export async function analyzeQuery(
     result: result.type,
     args: args.type,
     cardinality,
+    capabilities,
     query,
     importMap: imports,
     imports: imports.get("gel") ?? new Set(),

--- a/packages/gel/src/reflection/index.ts
+++ b/packages/gel/src/reflection/index.ts
@@ -31,3 +31,4 @@ export * from "./reservedKeywords";
 // export * from "./syntax";
 export * as introspect from "./queries";
 export * from "./analyzeQuery";
+export { Capabilities } from "../baseConn"

--- a/packages/gel/src/reflection/index.ts
+++ b/packages/gel/src/reflection/index.ts
@@ -31,4 +31,4 @@ export * from "./reservedKeywords";
 // export * from "./syntax";
 export * as introspect from "./queries";
 export * from "./analyzeQuery";
-export { Capabilities } from "../baseConn"
+export { Capabilities } from "../baseConn";

--- a/packages/gel/test/client.test.ts
+++ b/packages/gel/test/client.test.ts
@@ -1993,7 +1993,7 @@ test("describe", async () => {
     ).toMatchObject({
       cardinality: Cardinality.One,
       capabilities: Capabilities.MODIFICATONS,
-    })
+    });
   } finally {
     await client.execute(`drop type ScriptParseTest;`);
     await client.close();

--- a/packages/gel/test/client.test.ts
+++ b/packages/gel/test/client.test.ts
@@ -68,6 +68,8 @@ import { getHTTPSCRAMAuth } from "../src/httpScram";
 import cryptoUtils from "../src/cryptoUtils";
 import { getAuthenticatedFetch } from "../src/utils";
 import { Language } from "../src/ifaces";
+import { Cardinality } from "../src/reflection";
+import { Capabilities } from "../src/baseConn";
 
 class CancelTransaction extends Error {}
 
@@ -1976,6 +1978,25 @@ test("execute", async () => {
       });
   } finally {
     await con.close();
+  }
+});
+
+test("describe", async () => {
+  const client = getClient();
+  await client.execute(`create type ScriptParseTest {
+    create property name -> str;
+  };`);
+
+  try {
+    expect(
+      await client.describe(`insert ScriptParseTest { name := 'test' };`),
+    ).toMatchObject({
+      cardinality: Cardinality.One,
+      capabilities: Capabilities.MODIFICATONS,
+    })
+  } finally {
+    await client.execute(`drop type ScriptParseTest;`);
+    await client.close();
   }
 });
 


### PR DESCRIPTION
`client.describe()` (renamed from `client.parse()` for consistency with
other drivers) now returns the Capability bitmask.
