### PR TITLE
Return identity_id, if available, from signup

### DIFF
--- a/packages/auth-core/src/core.ts
+++ b/packages/auth-core/src/core.ts
@@ -94,7 +94,11 @@ export class Auth {
         tokenData: await this.getToken(result.code, verifier),
       };
     } else {
-      return { status: "verificationRequired", verifier };
+      return {
+        status: "verificationRequired",
+        verifier,
+        identity_id: result.identity_id ?? null,
+      };
     }
   }
 
@@ -161,7 +165,11 @@ export class Auth {
         tokenData: await this.getToken(result.code, verifier),
       };
     } else {
-      return { status: "verificationRequired", verifier };
+      return {
+        status: "verificationRequired",
+        verifier,
+        identity_id: result.identity_id ?? null,
+      };
     }
   }
 

--- a/packages/auth-core/src/types.ts
+++ b/packages/auth-core/src/types.ts
@@ -79,8 +79,12 @@ export interface TokenData {
 
 export type RegistrationResponse =
   | { code: string }
-  | { verification_email_sent_at: string };
+  | { verification_email_sent_at: string; identity_id?: string };
 
 export type SignupResponse =
   | { status: "complete"; verifier: string; tokenData: TokenData }
-  | { status: "verificationRequired"; verifier: string };
+  | {
+      status: "verificationRequired";
+      verifier: string;
+      identity_id: string | null;
+    };


### PR DESCRIPTION
In 6.0, we started returning the identity_id from signup even if email verification was required. This allows developers to create User objects connected to the newly created identity, even before the User verifies their email. It also allows developers to treat "missing PKCE" in the email verification flow as a success state that requires the end user to simply sign in again. This was difficult to do before because we treated the verification flow as the end of the "sign up" flow, but if you want to allow no-PKCE verification, you need to sign up the user before verification is complete.