### PR TITLE
Match CLI package logic to Python wrapper

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,6 +114,8 @@ jobs:
   test-cli-wrapper:
     name: "Test CLI Wrapper"
     runs-on: ubuntu-latest
+    env:
+      DEBUG: "*"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/packages/gel/src/cli.mts
+++ b/packages/gel/src/cli.mts
@@ -189,34 +189,7 @@ function runCli(
 async function findPackageUrl(): Promise<string> {
   const arch = os.arch();
   const platform = os.platform();
-  const [dist, ext] = getBaseDist(arch, platform);
 
-  const pkg = `${EDGEDB_PKG_ROOT}/${dist}/gel-cli${ext}`;
-  debug("  - Package found:", pkg);
-  return pkg;
-}
-
-async function downloadFile(url: string | URL, path: string) {
-  debug("Downloading file from URL:", url);
-  const response = await fetch(url);
-  if (!response.ok || !response.body) {
-    throw new Error(`  - Download failed: ${response.statusText}`);
-  }
-
-  const fileStream = createWriteStream(path, { flush: true });
-
-  if (response.body) {
-    for await (const chunk of streamReader(response.body)) {
-      fileStream.write(chunk);
-    }
-    fileStream.end();
-    debug("  - File downloaded successfully.");
-  } else {
-    throw new Error("  - Download failed: no response body");
-  }
-}
-
-function getBaseDist(platform: string, arch: string): [string, string] {
   debug("Getting base distribution for:", platform, arch);
   let dist = "";
   let ext = "";
@@ -240,8 +213,29 @@ function getBaseDist(platform: string, arch: string): [string, string] {
     throw new Error(`Unsupported OS: ${platform}`);
   }
 
-  debug("  - Base distribution:", dist);
-  return [dist, ext];
+  const pkg = `${EDGEDB_PKG_ROOT}/${dist}/gel-cli${ext}`;
+  debug("  - Package URL:", pkg);
+  return pkg;
+}
+
+async function downloadFile(url: string | URL, path: string) {
+  debug("Downloading file from URL:", url);
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    throw new Error(`  - Download failed: ${response.statusText}`);
+  }
+
+  const fileStream = createWriteStream(path, { flush: true });
+
+  if (response.body) {
+    for await (const chunk of streamReader(response.body)) {
+      fileStream.write(chunk);
+    }
+    fileStream.end();
+    debug("  - File downloaded successfully.");
+  } else {
+    throw new Error("  - Download failed: no response body");
+  }
 }
 
 function getInstallDir(cliPath: string): string {

--- a/packages/gel/src/cli.mts
+++ b/packages/gel/src/cli.mts
@@ -6,7 +6,6 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import * as process from "node:process";
-import * as semver from "semver";
 import envPaths from "env-paths";
 import Debug from "debug";
 import which from "which";
@@ -19,13 +18,6 @@ const SCRIPT_LOCATION = await fs.realpath(fileURLToPath(import.meta.url));
 const EDGEDB_PKG_ROOT = "https://packages.edgedb.com";
 const CACHE_DIR = envPaths("gel", { suffix: "" }).cache;
 const CACHED_CLI_PATH = path.join(CACHE_DIR, "/bin/gel");
-
-interface Package {
-  name: string;
-  version: string;
-  revision: string;
-  installref: string;
-}
 
 const SCRIPT_NAME = import.meta.url.split("/").pop() || "gel";
 
@@ -170,13 +162,12 @@ async function getCliLocationFromCachedCli(): Promise<string | null> {
 
 async function downloadCliPackage() {
   debug("Downloading CLI package...");
-  const cliPkg = await findPackage();
+  const cliPkgUrl = await findPackageUrl();
   const downloadDir = path.dirname(CACHED_CLI_PATH);
   await fs.mkdir(downloadDir, { recursive: true }).catch((error) => {
     if (error.code !== "EEXIST") throw error;
   });
-  const downloadUrl = new URL(cliPkg.installref, EDGEDB_PKG_ROOT);
-  await downloadFile(downloadUrl, CACHED_CLI_PATH);
+  await downloadFile(cliPkgUrl, CACHED_CLI_PATH);
   debug("  - CLI package downloaded to:", CACHED_CLI_PATH);
 
   const fd = await fs.open(CACHED_CLI_PATH, "r+");
@@ -195,85 +186,14 @@ function runCli(
   return execSync(command, execOptions);
 }
 
-async function findPackage(): Promise<Package> {
+async function findPackageUrl(): Promise<string> {
   const arch = os.arch();
   const platform = os.platform();
-  const includeCliPrereleases = true;
-  const cliVersionRange = ">=4.1.1";
-  const libc = platform === "linux" ? "musl" : "";
-  const dist = getBaseDist(arch, platform, libc);
+  const [dist, ext] = getBaseDist(arch, platform);
 
-  debug(`Finding compatible package for ${dist}...`);
-  const versionMap = await getVersionMap(dist);
-  const pkg = await getMatchingPkg(
-    versionMap,
-    cliVersionRange,
-    includeCliPrereleases,
-  );
-  if (!pkg) {
-    throw Error(
-      `No compatible Gel CLI package found for the current platform ${dist}`,
-    );
-  }
+  const pkg = `${EDGEDB_PKG_ROOT}/${dist}/gel-cli${ext}`;
   debug("  - Package found:", pkg);
   return pkg;
-}
-
-async function getVersionMap(dist: string): Promise<Map<string, Package>> {
-  debug("Getting version map for distribution:", dist);
-  const indexRequest = await fetch(
-    new URL(`archive/.jsonindexes/${dist}.json`, EDGEDB_PKG_ROOT),
-  );
-  const index = (await indexRequest.json()) as { packages: Package[] };
-  const versionMap = new Map();
-
-  for (const pkg of index.packages) {
-    if (pkg.name !== "edgedb-cli") {
-      continue;
-    }
-
-    if (
-      !versionMap.has(pkg.version) ||
-      versionMap.get(pkg.version).revision < pkg.revision
-    ) {
-      versionMap.set(pkg.version, pkg);
-    }
-  }
-
-  return versionMap;
-}
-
-async function getMatchingPkg(
-  versionMap: Map<string, Package>,
-  cliVersionRange: string,
-  includeCliPrereleases: boolean,
-): Promise<Package | null> {
-  debug("Getting matching version for range:", cliVersionRange);
-  let matchingPkg: Package | null = null;
-  for (const [version, pkg] of versionMap.entries()) {
-    if (
-      semver.satisfies(version, cliVersionRange, {
-        includePrerelease: includeCliPrereleases,
-      })
-    ) {
-      if (
-        !matchingPkg ||
-        semver.compareBuild(version, matchingPkg.version) > 0
-      ) {
-        matchingPkg = pkg;
-      }
-    }
-  }
-
-  if (matchingPkg) {
-    debug("  - Matching version found:", matchingPkg.version);
-    return matchingPkg;
-  } else {
-    throw Error(
-      "no published Gel CLI version matches requested version " +
-        `'${cliVersionRange}'`,
-    );
-  }
 }
 
 async function downloadFile(url: string | URL, path: string) {
@@ -296,33 +216,32 @@ async function downloadFile(url: string | URL, path: string) {
   }
 }
 
-function getBaseDist(arch: string, platform: string, libc = ""): string {
-  debug("Getting base distribution for:", arch, platform, libc);
-  let distArch = "";
-  let distPlatform = "";
-
-  if (platform === "linux") {
-    if (libc === "") {
-      libc = "gnu";
-    }
-    distPlatform = `unknown-linux-${libc}`;
-  } else if (platform === "darwin") {
-    distPlatform = "apple-darwin";
-  } else {
-    throw Error(`This action cannot be run on ${platform}`);
-  }
+function getBaseDist(platform: string, arch: string): [string, string] {
+  debug("Getting base distribution for:", platform, arch);
+  let dist = "";
+  let ext = "";
 
   if (arch === "x64") {
-    distArch = "x86_64";
+    dist += "x86_64";
   } else if (arch === "arm64") {
-    distArch = "aarch64";
+    dist += "aarch64";
   } else {
-    throw Error(`This action does not support the ${arch} architecture`);
+    throw new Error(`Unsupported architecture: ${arch}`);
   }
 
-  const dist = `${distArch}-${distPlatform}`;
+  if (platform === "win32") {
+    dist += "-pc-windows-msvc";
+    ext = ".exe";
+  } else if (platform === "darwin") {
+    dist += "-apple-darwin";
+  } else if (platform === "linux") {
+    dist += "-unknown-linux-musl";
+  } else {
+    throw new Error(`Unsupported OS: ${platform}`);
+  }
+
   debug("  - Base distribution:", dist);
-  return dist;
+  return [dist, ext];
 }
 
 function getInstallDir(cliPath: string): string {

--- a/packages/gel/src/cli.mts
+++ b/packages/gel/src/cli.mts
@@ -222,7 +222,7 @@ async function downloadFile(url: string | URL, path: string) {
   debug("Downloading file from URL:", url);
   const response = await fetch(url);
   if (!response.ok || !response.body) {
-    throw new Error(`  - Download failed: ${response.statusText}`);
+    throw new Error(`Download from ${url} failed: ${response.statusText}`);
   }
 
   const fileStream = createWriteStream(path, { flush: true });

--- a/packages/gel/src/cli.mts
+++ b/packages/gel/src/cli.mts
@@ -186,7 +186,7 @@ function runCli(
   return execSync(command, execOptions);
 }
 
-async function findPackageUrl(): Promise<string> {
+async function findPackageUrl(): Promise<URL> {
   const arch = os.arch();
   const platform = os.platform();
 
@@ -213,8 +213,8 @@ async function findPackageUrl(): Promise<string> {
     throw new Error(`Unsupported OS: ${platform}`);
   }
 
-  const pkg = `${EDGEDB_PKG_ROOT}/${dist}/gel-cli${ext}`;
-  debug("  - Package URL:", pkg);
+  const pkg = new URL(`/dist/${dist}/gel-cli${ext}`, EDGEDB_PKG_ROOT);
+  debug("  - Package URL:", pkg.href);
   return pkg;
 }
 


### PR DESCRIPTION
- Drop the index lookup and assemble the CLI package URL directly.
- Add support for `win32` platform.
- Drop `-gnu` libc: this was never used and we don't build for it.