### PR TITLE
Export more types and classes from `gel` package

### DIFF
--- a/packages/gel/src/index.node.ts
+++ b/packages/gel/src/index.node.ts
@@ -23,9 +23,14 @@ export { createClient, createHttpClient } from "./nodeClient";
 
 import * as systemUtils from "./systemUtils";
 export { systemUtils };
+export type { TransactionOptions, SimpleTransactionOptions } from "./options";
 
 export { RawConnection as _RawConnection } from "./rawConn";
-export type { Client, ConnectOptions } from "./baseClient";
+export {
+  ResolvedConnectConfig,
+  type NormalizedConnectConfig,
+} from "./conUtils";
+export { Client, type ConnectOptions } from "./baseClient";
 
 export * from "./index.shared";
 export * as $ from "./reflection/index";

--- a/packages/gel/src/index.shared.ts
+++ b/packages/gel/src/index.shared.ts
@@ -43,6 +43,9 @@ export {
   defaultBackoff,
   logWarnings,
   throwWarnings,
+  type SimpleRetryOptions,
+  type SimpleConfig,
+  type CodecSpec,
 } from "./options";
 export type { BackoffFunction, WarningHandler } from "./options";
 


### PR DESCRIPTION
In general, we want to expose all types and classes that end users actually interact with, so this is an attempt to explicitly export _more_ of those.