### PR TITLE
Fix handling of assert_single wrapped select/update exprs when used as e.with expr

### DIFF
--- a/integration-tests/lts/select.test.ts
+++ b/integration-tests/lts/select.test.ts
@@ -1739,4 +1739,26 @@ SELECT __scope_0_defaultPerson {
 
     await query2.run(client);
   });
+
+  test("assert_single wrapped select as expr in e.with", async () => {
+    const movies = e.select(e.Movie, () => ({
+      title: true,
+    }));
+
+    const query = e.with(
+      [movies],
+      e.select(e.User, (user) => ({
+        // use filter_single with e.op to force select to be wrapped in assert_single
+        filter_single: e.op(
+          user.id,
+          "=",
+          e.uuid("4d0f90b1-de94-4c79-ba56-3e0acdfbd06d"),
+        ),
+        username: true,
+        some_movies: movies,
+      })),
+    );
+
+    await query.run(client);
+  });
 });

--- a/packages/generate/src/syntax/path.ts
+++ b/packages/generate/src/syntax/path.ts
@@ -32,6 +32,7 @@ import type {
   ScalarType,
 } from "./typesystem";
 import type { future } from "./future";
+import type { $expr_Function } from "./funcops";
 // import {typeutil} from "./typeutil";
 // import {cardutil} from "./cardinality";
 
@@ -391,6 +392,16 @@ export function $assert_single(expr: Expression) {
     __args__: [expr],
     __namedargs__: {},
   }) as any;
+}
+
+export function $unwrap_assert_single(expr: Expression) {
+  if (
+    (expr as any).__kind__ === ExpressionKind.Function &&
+    (expr as $expr_Function).__name__ === "std::assert_single"
+  ) {
+    return (expr as $expr_Function).__args__[0] as Expression;
+  }
+  return null;
 }
 
 const jsonDestructureProxyHandlers: ProxyHandler<ExpressionRoot> = {

--- a/packages/generate/src/syntax/with.ts
+++ b/packages/generate/src/syntax/with.ts
@@ -5,7 +5,7 @@ import type { $expr_For } from "./for";
 import type { $expr_Insert } from "./insert";
 import type { $expr_Update } from "./update";
 import type { $expr_Group } from "./group";
-import { $expressionify } from "./path";
+import { $assert_single, $expressionify, $unwrap_assert_single } from "./path";
 
 export type $expr_Alias<
   El extends BaseType = BaseType,
@@ -50,13 +50,21 @@ function _with<Expr extends WithableExpression>(
   refs: Expression[],
   expr: Expr,
 ): $expr_With<Expr> {
-  return $expressionify({
+  // handle case where e.select/e.update wraps their select/update expr in
+  // assert_single, for which we need to unwrap so refs are attached to the
+  // with block of the inner select/update expr, and then re-wrap the whole
+  // 'with' expr with assert_single
+  const unwrapped = $unwrap_assert_single(expr);
+
+  const withExpr = $expressionify({
     __kind__: ExpressionKind.With,
     __element__: expr.__element__,
     __cardinality__: expr.__cardinality__,
     __refs__: refs,
-    __expr__: expr as any,
+    __expr__: (unwrapped ?? expr) as any,
   }) as any;
+
+  return unwrapped ? $assert_single(withExpr) : withExpr;
 }
 
 export { _with as with };


### PR DESCRIPTION
When using `filter_single` with `e.op` in select or update, we wrap the output select/update expr in an `assert_single()` call to ensure type correctness, but lie to the typesystem that the returned expression is still a select/update expr.

So when one of these wrapped select/update expressions is passed to `e.with` as the `expr` arg, it gets tripped up by the expr actually being an assert_single function expression instead of a 'withable' expr, and fails to attach the refs to the with block of the wrapped select/update expr, generating broken queries.

This PR updates `e.with` to handle `assert_single` wrapped select/update exprs by moving the `assert_single` to wrap the whole `with` expr, so refs are correctly attached to the inner select/update expr by `toEdgeQL`.