### PR TITLE
Add benchmark for query throughput

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     continue-on-error: ${{ matrix.gel-version == 'nightly' }}
     strategy:
       matrix:
-        node-version: ["18", "20", "22", "23"]
+        node-version: ["20", "22", "23"]
         os: [ubuntu-latest]
         gel-version: ["stable"]
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,8 +86,8 @@ jobs:
         if: ${{ matrix.gel-version == '4' || matrix.gel-version == '5' || matrix.gel-version == 'stable' || matrix.gel-version == 'nightly' }}
         run: |
           turbo run ci:integration-test --filter=@gel/integration-lts
-          turbo run bench:types --filter=@gel/integration-lts || echo "Benchmark types script failed, proceeding anyway."
-          turbo run bench:runtime --filter=@gel/integration-lts || echo "Benchmark types script failed, proceeding anyway."
+          yarn workspace @gel/integration-lts run bench:types || echo "Benchmark types script failed, proceeding anyway."
+          yarn workspace @gel/integration-lts run bench:runtime || echo "Benchmark types script failed, proceeding anyway."
 
       - name: Run query builder integration tests stable
         if: ${{ matrix.gel-version == 'stable' || matrix.gel-version == 'nightly' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,6 @@ jobs:
         run: |
           turbo run ci:integration-test --filter=@gel/integration-lts
           yarn workspace @gel/integration-lts run bench:types || echo "Benchmark types script failed, proceeding anyway."
-          yarn workspace @gel/integration-lts run bench:runtime || echo "Benchmark types script failed, proceeding anyway."
 
       - name: Run query builder integration tests stable
         if: ${{ matrix.gel-version == 'stable' || matrix.gel-version == 'nightly' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,6 +87,7 @@ jobs:
         run: |
           turbo run ci:integration-test --filter=@gel/integration-lts
           turbo run bench:types --filter=@gel/integration-lts || echo "Benchmark types script failed, proceeding anyway."
+          turbo run bench:runtime --filter=@gel/integration-lts || echo "Benchmark types script failed, proceeding anyway."
 
       - name: Run query builder integration tests stable
         if: ${{ matrix.gel-version == 'stable' || matrix.gel-version == 'nightly' }}

--- a/integration-tests/lts/package.json
+++ b/integration-tests/lts/package.json
@@ -14,7 +14,7 @@
     "test:cjs": "yarn generate queries --target cjs --file cjs/queries && yarn generate edgeql-js --target cjs --output-dir cjs/edgeql-js && cd cjs && node test.js",
     "test:mts": "yarn generate queries --target mts --file mts/queries && yarn generate edgeql-js --target mts --output-dir mts/edgeql-js && cd mts && yarn build && node dist/test.js",
     "ci:integration-test": "tsx ./testRunner.ts",
-    "bench:types": "cd ../.. && tsx integration-tests/lts/bench.ts",
+    "bench:types": "tsx ./bench.ts",
     "bench:runtime": "yarn generate edgeql-js --target mts --output-dir mts/edgeql-js && tsx ./throughput.bench.mts"
   },
   "devDependencies": {

--- a/integration-tests/lts/package.json
+++ b/integration-tests/lts/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@arktype/attest": "^0.7.8",
-    "@gel/generate": "^0.6.0-rc",
+    "@gel/generate": "*",
     "@tsconfig/node-lts": "^20.1.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.13",
@@ -29,7 +29,8 @@
     "typescript": "^5.5.2"
   },
   "dependencies": {
-    "gel": "^2.0.0-rc",
-    "fast-check": "^3.19.0"
+    "fast-check": "^3.19.0",
+    "gel": "*",
+    "tinybench": "^4.0.1"
   }
 }

--- a/integration-tests/lts/package.json
+++ b/integration-tests/lts/package.json
@@ -14,7 +14,8 @@
     "test:cjs": "yarn generate queries --target cjs --file cjs/queries && yarn generate edgeql-js --target cjs --output-dir cjs/edgeql-js && cd cjs && node test.js",
     "test:mts": "yarn generate queries --target mts --file mts/queries && yarn generate edgeql-js --target mts --output-dir mts/edgeql-js && cd mts && yarn build && node dist/test.js",
     "ci:integration-test": "tsx ./testRunner.ts",
-    "bench:types": "cd ../.. && tsx integration-tests/lts/bench.ts"
+    "bench:types": "cd ../.. && tsx integration-tests/lts/bench.ts",
+    "bench:runtime": "yarn generate edgeql-js --target mts --output-dir mts/edgeql-js && tsx ./throughput.bench.mts"
   },
   "devDependencies": {
     "@arktype/attest": "^0.7.8",

--- a/integration-tests/lts/testRunner.ts
+++ b/integration-tests/lts/testRunner.ts
@@ -30,6 +30,13 @@ import {
     console.log(`\nRunning tests...`);
     await runCommand("yarn", ["test:ts"], configToEnv(config));
     await runCommand("yarn", ["test:non_ts"], configToEnv(config));
+    try {
+      await runCommand("yarn", ["bench:types"], configToEnv(config));
+      await runCommand("yarn", ["bench:runtime"], configToEnv(config));
+    } catch (err) {
+      console.error("Benchmarking failed, proceeding anyway.");
+      console.error(err);
+    }
   } catch (err) {
     console.error(err);
     process.exit(1);

--- a/integration-tests/lts/testRunner.ts
+++ b/integration-tests/lts/testRunner.ts
@@ -31,8 +31,8 @@ import {
     await runCommand("yarn", ["test:ts"], configToEnv(config));
     await runCommand("yarn", ["test:non_ts"], configToEnv(config));
     try {
-      await runCommand("yarn", ["bench:types"], configToEnv(config));
       await runCommand("yarn", ["bench:runtime"], configToEnv(config));
+      await runCommand("yarn", ["bench:types"], configToEnv(config));
     } catch (err) {
       console.error("Benchmarking failed, proceeding anyway.");
       console.error(err);

--- a/integration-tests/lts/throughput.bench.mts
+++ b/integration-tests/lts/throughput.bench.mts
@@ -1,0 +1,89 @@
+import { Bench } from "tinybench";
+import { createClient } from "gel";
+import e from "./mts/edgeql-js/index.mjs";
+
+const client = createClient();
+
+const bench = new Bench({
+  name: "Query throughput",
+  warmup: true,
+
+  setup: async (_task, mode) => {
+    if (mode === "warmup") {
+      await client.ensureConnected();
+    }
+  },
+  time: 5_000,
+});
+
+bench.add("simple select", async () => {
+  const q = e.select(e.Hero, () => ({
+    limit: 1,
+  }));
+
+  await q.run(client);
+});
+
+bench.add("complex nested insert", async () => {
+  const q = e
+    .insert(e.Movie, {
+      title: "The Matrix",
+      genre: "Science Fiction",
+      rating: 8.7,
+      release_year: 1999,
+      characters: e.select(e.Hero),
+    })
+    .unlessConflict();
+
+  await q.run(client);
+});
+
+bench.add(
+  "complex select: polymorphic link properties in expressions",
+  async () => {
+    const query = e.select(e.Object, () => ({
+      id: true,
+      ...e.is(e.Movie, {
+        title: true,
+        characters: (char) => ({
+          name: true,
+          "@character_name": true,
+          char_name: char["@character_name"],
+          person_name: char.name,
+
+          filter: e.op(char["@character_name"], "ilike", "a%"),
+        }),
+      }),
+    }));
+
+    await query.run(client);
+  },
+);
+
+await bench.run();
+
+console.table(
+  bench.table((t) => {
+    if (!t.result) {
+      return {
+        name: t.name,
+        mean: "N/A",
+        median: "N/A",
+        samples: 0,
+      };
+    }
+    const { error, throughput } = t.result;
+    if (error) {
+      return {
+        name: t.name,
+        Error: error.message,
+        Stack: error.stack,
+      };
+    }
+    return {
+      name: t.name,
+      mean: `${Math.round(throughput.mean).toString()} \xb1 ${throughput.rme.toFixed(2)}%`,
+      median: `${Math.round(throughput.p50!).toString()} \xb1 ${Math.round(throughput.mad!).toString()}`,
+    };
+  }),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4548,19 +4548,9 @@ jest-worker@^29.7.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@29.7.0:
+jest@29.7.0, jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz"
-  integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==
-  dependencies:
-    "@jest/core" "^29.7.0"
-    "@jest/types" "^29.6.3"
-    import-local "^3.0.2"
-    jest-cli "^29.7.0"
-
-jest@^29.7.0:
-  version "29.7.0"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-29.7.0.tgz#994676fc24177f088f1c5e3737f5697204ff2613"
   integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==
   dependencies:
     "@jest/core" "^29.7.0"
@@ -5904,16 +5894,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5938,14 +5919,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6099,6 +6073,11 @@ tiny-invariant@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
+
+tinybench@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-4.0.1.tgz#ff5940b4e4a63892ef0cad3daf148d5fd8a3725b"
+  integrity sha512-Nb1srn7dvzkVx0J5h1vq8f48e3TIcbrS7e/UfAI/cDSef/n8yLh4zsAEsFkfpw6auTY+ZaspEvam/xs8nMnotQ==
 
 tinyexec@^0.3.1:
   version "0.3.1"
@@ -6544,16 +6523,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
Make it easier to ensure we don't regress query throughput when making changes to low-level query code. No automatic guard rails here, but having the script run in CI at least gives us the opportunity to check.