### PR TITLE
Set default transaction options from `withTransactionOptions`

### DIFF
--- a/packages/gel/src/baseConn.ts
+++ b/packages/gel/src/baseConn.ts
@@ -482,7 +482,7 @@ export class BaseRawConnection {
     throw new errors.ProtocolError("invalid input codec");
   }
 
-  private isInTransaction(): boolean {
+  private _isInTransaction(): boolean {
     return (
       this.serverXactStatus === TransactionStatus.TRANS_INTRANS ||
       this.serverXactStatus === TransactionStatus.TRANS_ACTIVE
@@ -561,7 +561,7 @@ export class BaseRawConnection {
           state.config.get("default_transaction_isolation")
         ) {
           let newState = state;
-          if (isExecute && !this.isInTransaction()) {
+          if (isExecute && !this._isInTransaction()) {
             newState = state.withConfig({
               default_transaction_isolation: state.transactionOptions.isolation,
             });

--- a/packages/gel/src/baseConn.ts
+++ b/packages/gel/src/baseConn.ts
@@ -557,8 +557,9 @@ export class BaseRawConnection {
         // set as the default isolation level for this query if it is not already
         // in a transaction. If they match, do nothing.
         if (
+          versionGreaterThanOrEqual(this.protocolVersion, [3, 0]) &&
           state.transactionOptions.isolation !==
-          state.config.get("default_transaction_isolation")
+            state.config.get("default_transaction_isolation")
         ) {
           let newState = state;
           if (isExecute && !this._isInTransaction()) {

--- a/packages/gel/src/baseConn.ts
+++ b/packages/gel/src/baseConn.ts
@@ -560,12 +560,13 @@ export class BaseRawConnection {
           state.transactionOptions.isolation !==
           state.config.get("default_transaction_isolation")
         ) {
+          let newState = state;
           if (isExecute && !this.isInTransaction()) {
-            state = state.withConfig({
+            newState = state.withConfig({
               default_transaction_isolation: state.transactionOptions.isolation,
             });
           }
-          encodedState = this._setStateCodec(state);
+          encodedState = this._setStateCodec(newState);
         } else {
           encodedState = this.stateCache.get(state) ?? null;
           if (encodedState === null) {

--- a/packages/gel/src/options.ts
+++ b/packages/gel/src/options.ts
@@ -432,7 +432,9 @@ export class Options {
       this.config.size === 0 &&
       this.globals.size === 0 &&
       this.moduleAliases.size === 0 &&
-      this.module === "default"
+      this.module === "default" &&
+      this.transactionOptions === TransactionOptions.defaults() &&
+      this.retryOptions === RetryOptions.defaults()
     );
   }
 

--- a/packages/gel/src/options.ts
+++ b/packages/gel/src/options.ts
@@ -18,6 +18,11 @@ export enum IsolationLevel {
   RepeatableRead = "RepeatableRead",
 }
 
+export const IsolationLevelMap = {
+  [IsolationLevel.Serializable]: "SERIALIZABLE",
+  [IsolationLevel.RepeatableRead]: "REPEATABLE READ",
+} as const;
+
 export enum RetryCondition {
   TransactionConflict,
   NetworkError,

--- a/packages/gel/src/options.ts
+++ b/packages/gel/src/options.ts
@@ -129,6 +129,14 @@ export class TransactionOptions {
     this.deferrable = deferrable;
   }
 
+  isDefault(): boolean {
+    return (
+      this.isolation === undefined &&
+      this.readonly === undefined &&
+      this.deferrable === undefined
+    );
+  }
+
   static defaults(): TransactionOptions {
     return _defaultTransactionOptions;
   }
@@ -433,7 +441,7 @@ export class Options {
       this.globals.size === 0 &&
       this.moduleAliases.size === 0 &&
       this.module === "default" &&
-      this.transactionOptions === TransactionOptions.defaults()
+      this.transactionOptions.isDefault()
     );
   }
 

--- a/packages/gel/src/options.ts
+++ b/packages/gel/src/options.ts
@@ -116,13 +116,13 @@ export interface SimpleTransactionOptions {
 export class TransactionOptions {
   // This type is immutable.
 
-  readonly isolation: IsolationLevel;
-  readonly readonly: boolean;
-  readonly deferrable: boolean;
+  readonly isolation: IsolationLevel | undefined;
+  readonly readonly: boolean | undefined;
+  readonly deferrable: boolean | undefined;
   constructor({
-    isolation = IsolationLevel.Serializable,
-    readonly = false,
-    deferrable = false,
+    isolation,
+    readonly,
+    deferrable,
   }: SimpleTransactionOptions = {}) {
     this.isolation = isolation;
     this.readonly = readonly;
@@ -433,8 +433,7 @@ export class Options {
       this.globals.size === 0 &&
       this.moduleAliases.size === 0 &&
       this.module === "default" &&
-      this.transactionOptions === TransactionOptions.defaults() &&
-      this.retryOptions === RetryOptions.defaults()
+      this.transactionOptions === TransactionOptions.defaults()
     );
   }
 

--- a/packages/gel/src/options.ts
+++ b/packages/gel/src/options.ts
@@ -14,8 +14,8 @@ export function defaultBackoff(attempt: number): number {
 }
 
 export enum IsolationLevel {
-  Serializable = "SERIALIZABLE",
-  RepeatableRead = "REPEATABLE READ",
+  Serializable = "Serializable",
+  RepeatableRead = "RepeatableRead",
 }
 
 export enum RetryCondition {

--- a/packages/gel/src/transaction.ts
+++ b/packages/gel/src/transaction.ts
@@ -27,6 +27,7 @@ import {
   type SQLQueryArgs,
 } from "./ifaces";
 import type { Options } from "./options";
+import { IsolationLevelMap } from "./options";
 
 export enum TransactionState {
   ACTIVE = 0,
@@ -62,8 +63,14 @@ export class TransactionImpl {
     await rawConn.resetState();
 
     const options = holder.options.transactionOptions;
+    const isolationLevelStr = IsolationLevelMap[options.isolation];
+    if (!isolationLevelStr) {
+      throw new errors.InterfaceError(
+        `Invalid isolation level: ${options.isolation}`,
+      );
+    }
     await rawConn.fetch(
-      `START TRANSACTION ISOLATION ${options.isolation}, ${
+      `START TRANSACTION ISOLATION ${isolationLevelStr}, ${
         options.readonly ? "READ ONLY" : "READ WRITE"
       }, ${options.deferrable ? "" : "NOT "}DEFERRABLE;`,
       undefined,

--- a/packages/gel/src/transaction.ts
+++ b/packages/gel/src/transaction.ts
@@ -66,12 +66,13 @@ export class TransactionImpl {
     const txOptions = [];
 
     if (options.isolation !== undefined) {
-      if (!IsolationLevelMap[options.isolation]) {
+      const maybeLevelText = IsolationLevelMap[options.isolation];
+      if (!maybeLevelText) {
         throw new errors.InterfaceError(
           `Invalid isolation level: ${options.isolation}`,
         );
       }
-      txOptions.push(`ISOLATION ${IsolationLevelMap[options.isolation]}`);
+      txOptions.push(`ISOLATION ${maybeLevelText}`);
     }
     if (options.readonly !== undefined) {
       txOptions.push(options.readonly ? "READ ONLY" : "READ WRITE");


### PR DESCRIPTION
If an explicit isolation level and/or access mode is set in the transaction options, set the corresponding default transaction options that controls implicit transactions to this explicit value.