### PR TITLE
Do not quote "runner" command

### DIFF
--- a/packages/create/src/utils.ts
+++ b/packages/create/src/utils.ts
@@ -187,7 +187,7 @@ export class PackageManager {
     args: string[] = [],
     options?: SpawnOptionsWithoutStdio,
   ): Promise<{ stdout: string; stderr: string }> {
-    const command = quote([this.runner, binName, ...args]);
+    const command = `${this.runner} ${quote([binName, ...args])}`;
     return execInLoginShell(command, options);
   }
 }


### PR DESCRIPTION
It was turning space-separated commands (like `pnpm dlx`) into a single quoted call like `'pnpm dlx'`. Move the runner command out of the quoting to avoid that quoting