### PR TITLE
Fix type error when e.with() wraps unlessConflict()

### DIFF
--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -155,9 +155,9 @@ describe("insert", () => {
     );
 
     assert.deepEqual(query.__cardinality__, $.Cardinality.One);
-    tc.assert<
-      tc.IsExact<(typeof query)["__cardinality__"], $.Cardinality.One>
-    >(true);
+    tc.assert<tc.IsExact<(typeof query)["__cardinality__"], $.Cardinality.One>>(
+      true,
+    );
 
     const result = await query.run(client);
 

--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -161,7 +161,7 @@ describe("insert", () => {
     >(true);
 
     const result = await query.run(client);
-    // Type of the result should be `{id: string} | null`
+    
     tc.assert<tc.IsExact<typeof result, number>>(true);
     assert.equal(result, 42);
   });

--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -143,7 +143,10 @@ describe("insert", () => {
   test("with wrapping insert .unlessConflict()", async () => {
     const dep = e.insert(e.Character, {
       name: "dependency",
-    });
+    }).unlessConflict((character) => ({
+      on: character.name,
+      else: character
+    }));
 
     const query = e.with(
       [dep], // dependency used inside the insert expression

--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -142,12 +142,12 @@ describe("insert", () => {
 
   test("with wrapping insert .unlessConflict()", async () => {
     const dep = e
-      .insert(e.Character, {
+      .insert(e.Person, {
         name: "dependency",
       })
-      .unlessConflict((character) => ({
-        on: character.name,
-        else: character,
+      .unlessConflict((person) => ({
+        on: person.name,
+        else: person,
       }));
 
     const query = e.with(
@@ -155,7 +155,7 @@ describe("insert", () => {
       e
         .insert(e.Movie, {
           title: "WithUnlessConflict – test",
-          characters: dep,
+          actors: dep,
         })
         .unlessConflict((movie) => ({
           on: movie.title,

--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -142,12 +142,11 @@ describe("insert", () => {
 
   test("with wrapping insert .unlessConflict()", async () => {
     const dep = e
-      .insert(e.Person, {
+      .insert(e.Hero, {
         name: "dependency",
       })
-      .unlessConflict((person) => ({
-        on: person.name,
-        else: person,
+      .unlessConflict((hero) => ({
+        on: hero.name,
       }));
 
     const query = e.with(
@@ -155,14 +154,14 @@ describe("insert", () => {
       e.select(e.int16(42)),
     );
 
-    assert.deepEqual(query.__cardinality__, $.Cardinality.AtMostOne);
+    assert.deepEqual(query.__cardinality__, $.Cardinality.One);
     tc.assert<
-      tc.IsExact<(typeof query)["__cardinality__"], $.Cardinality.AtMostOne>
+      tc.IsExact<(typeof query)["__cardinality__"], $.Cardinality.One>
     >(true);
 
     const result = await query.run(client);
 
-    tc.assert<tc.IsExact<typeof result, number>>(true);
+    tc.assert<tc.IsExact<typeof result, 42>>(true);
     assert.equal(result, 42);
   });
 

--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -163,8 +163,8 @@ describe("insert", () => {
 
     const result = await query.run(client);
     // Type of the result should be `{id: string} | null`
-    tc.assert<tc.IsExact<typeof result, { id: string } | null>>(true);
-    assert.ok(result?.id);
+    tc.assert<tc.IsExact<typeof result, number>>(true);
+    assert.equal(result, 42);
   });
 
   test("nested insert", async () => {

--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -155,7 +155,6 @@ describe("insert", () => {
       e.select(e.int16(42)),
     );
 
-    // The presence of `.unlessConflict()` should make the result AtMostOne
     assert.deepEqual(query.__cardinality__, $.Cardinality.AtMostOne);
     tc.assert<
       tc.IsExact<(typeof query)["__cardinality__"], $.Cardinality.AtMostOne>

--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -155,7 +155,7 @@ describe("insert", () => {
       e
         .insert(e.Movie, {
           title: "WithUnlessConflict – test",
-          actors: dep,
+          movie_characters: dep,
         })
         .unlessConflict((movie) => ({
           on: movie.title,

--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -141,12 +141,14 @@ describe("insert", () => {
   });
 
   test("with wrapping insert .unlessConflict()", async () => {
-    const dep = e.insert(e.Character, {
-      name: "dependency",
-    }).unlessConflict((character) => ({
-      on: character.name,
-      else: character
-    }));
+    const dep = e
+      .insert(e.Character, {
+        name: "dependency",
+      })
+      .unlessConflict((character) => ({
+        on: character.name,
+        else: character,
+      }));
 
     const query = e.with(
       [dep], // dependency used inside the insert expression

--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -151,7 +151,7 @@ describe("insert", () => {
       }));
 
     const query = e.with(
-      [dep], // dependency used inside the insert expression
+      [dep], // test dependency with an unlessConflict() inside it
       e.select(e.int16(42)),
     );
 

--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -161,7 +161,7 @@ describe("insert", () => {
     >(true);
 
     const result = await query.run(client);
-    
+
     tc.assert<tc.IsExact<typeof result, number>>(true);
     assert.equal(result, 42);
   });

--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -152,16 +152,7 @@ describe("insert", () => {
 
     const query = e.with(
       [dep], // dependency used inside the insert expression
-      e
-        .insert(e.Movie, {
-          title: "WithUnlessConflict – test",
-          characters: e.select(dep, () => ({
-            "@character_name": "Peter Quill",
-          })),
-        })
-        .unlessConflict((movie) => ({
-          on: movie.title,
-        })),
+      e.select(e.int16(42)),
     );
 
     // The presence of `.unlessConflict()` should make the result AtMostOne

--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -141,15 +141,16 @@ describe("insert", () => {
   });
 
   test("with wrapping insert .unlessConflict()", async () => {
-    const dep = e.float64(1.23);
+    const dep = e.insert(e.Character, {
+      name: "dependency",
+    });
 
     const query = e.with(
       [dep], // dependency used inside the insert expression
       e
         .insert(e.Movie, {
           title: "WithUnlessConflict – test",
-          // use `dep` so the WITH variable is referenced
-          rating: dep,
+          characters: dep,
         })
         .unlessConflict((movie) => ({
           on: movie.title,

--- a/integration-tests/lts/insert.test.ts
+++ b/integration-tests/lts/insert.test.ts
@@ -155,7 +155,9 @@ describe("insert", () => {
       e
         .insert(e.Movie, {
           title: "WithUnlessConflict – test",
-          movie_characters: dep,
+          characters: e.select(dep, () => ({
+            "@character_name": "Peter Quill",
+          })),
         })
         .unlessConflict((movie) => ({
           on: movie.title,

--- a/packages/generate/src/syntax/with.ts
+++ b/packages/generate/src/syntax/with.ts
@@ -2,7 +2,7 @@ import { type Cardinality, ExpressionKind } from "gel/dist/reflection/index";
 import type { BaseType, Expression, TypeSet } from "./typesystem";
 import type { $expr_Select } from "./select";
 import type { $expr_For } from "./for";
-import type { $expr_Insert } from "./insert";
+import type { $expr_Insert, $expr_InsertUnlessConflict } from "./insert";
 import type { $expr_Update } from "./update";
 import type { $expr_Group } from "./group";
 import { $assert_single, $expressionify, $unwrap_assert_single } from "./path";
@@ -32,6 +32,7 @@ export type WithableExpression =
   | $expr_Select
   | $expr_For
   | $expr_Insert
+  | $expr_InsertUnlessConflict
   | $expr_Update
   | $expr_Group;
 


### PR DESCRIPTION
discussed in Slack with Scott - insertUnlessConflict should be `Withable` also

there actually weren't any previous tests explicitly testing `insert` is `withable`, but added one anyway for `unlessConflict`