### PR TITLE
Add provider ID token to TokenData type

### DIFF
--- a/packages/auth-core/src/core.ts
+++ b/packages/auth-core/src/core.ts
@@ -61,8 +61,14 @@ export class Auth {
     return new AuthPCKESession(this, challenge, verifier);
   }
 
-  getToken(code: string, verifier: string): Promise<TokenData> {
-    return this._get<TokenData>(`token`, { code, verifier });
+  async getToken(code: string, verifier: string): Promise<TokenData> {
+    const tokenData = await this._get<TokenData>(`token`, { code, verifier });
+    // n.b. Versions before v6 did not return the provider_id_token or identity_id
+    return {
+      ...tokenData,
+      identity_id: tokenData.identity_id ?? null,
+      provider_id_token: tokenData.provider_id_token ?? null,
+    };
   }
 
   getWebAuthnSignupOptionsUrl(email: string) {

--- a/packages/auth-core/src/types.ts
+++ b/packages/auth-core/src/types.ts
@@ -75,6 +75,7 @@ export interface TokenData {
   identity_id: string | null;
   provider_token: string | null;
   provider_refresh_token: string | null;
+  provider_id_token: string | null;
 }
 
 export type RegistrationResponse =


### PR DESCRIPTION
We added this in v6 along with the `identity_id`.