### PR TITLE
Turn off labels in nextjs create dev command

### DIFF
--- a/packages/create/src/recipes/nextjs/index.ts
+++ b/packages/create/src/recipes/nextjs/index.ts
@@ -22,7 +22,7 @@ const recipe: Recipe = {
       scripts: {
         "dev:next": "next dev",
         "dev:gel": "gel watch --migrate",
-        dev: "run-p --print-label dev:*",
+        dev: "run-p dev:*",
         "db:generate": "run-s --print-label db:generate:*",
         "db:generate:qb": `${packageManager.runner} generate edgeql-js`,
         "db:generate:queries": `${packageManager.runner} generate queries`,


### PR DESCRIPTION
Our watch tool does fancy terminal manipulation (progress bars, coloring, line replacement, etc), and buffering into a labeled string was hiding some important information. Since the watch already has pretty verbose output, just skip labeling the output.