### PR TITLE
Await deleting the auth cookie

### DIFF
--- a/packages/auth-nextjs/src/shared.ts
+++ b/packages/auth-nextjs/src/shared.ts
@@ -614,7 +614,7 @@ export abstract class NextAuth extends NextAuthHelpers {
                 `'onSignout' auth route handler not configured`,
               );
             }
-            this.deleteAuthCookie();
+            await this.deleteAuthCookie();
             return onSignout(req);
           }
           default:


### PR DESCRIPTION
This fixes the signout route not actually deleting the auth cookie. In newer versions of Next.js, getting the cookie store is async, so this used to work, but when we fixed support for async cookies in Next.js > 15, we missed this one callsite.