### PR TITLE
feat: allow users to customize the TypeScript type of a custom scalar

### DIFF
--- a/packages/gel/src/codecTypeRegistry.ts
+++ b/packages/gel/src/codecTypeRegistry.ts
@@ -1,0 +1,7 @@
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface OverrideCodecType {}
+
+export type ResolvedCodecType<TDbTypeName, TDefaultTsType> =
+  TDbTypeName extends keyof OverrideCodecType
+    ? OverrideCodecType[TDbTypeName]
+    : TDefaultTsType;

--- a/packages/gel/src/index.shared.ts
+++ b/packages/gel/src/index.shared.ts
@@ -53,6 +53,8 @@ export * from "./errors";
 
 export type { Codecs } from "./codecs/codecs";
 
+export type { OverrideCodecType, ResolvedCodecType } from "./codecTypeRegistry";
+
 /* Private APIs */
 import type * as codecs from "./codecs/ifaces";
 import * as reg from "./codecs/registry";

--- a/packages/gel/src/index.shared.ts
+++ b/packages/gel/src/index.shared.ts
@@ -57,8 +57,10 @@ export type { OverrideCodecType, ResolvedCodecType } from "./codecTypeRegistry";
 
 /* Private APIs */
 import type * as codecs from "./codecs/ifaces";
+import { ScalarCodec } from "./codecs/ifaces";
 import * as reg from "./codecs/registry";
 import * as buf from "./primitives/buffer";
 export const _CodecsRegistry = reg.CodecsRegistry;
 export const _ReadBuffer = buf.ReadBuffer;
 export type _ICodec = codecs.ICodec;
+export const _ScalarCodec = ScalarCodec;

--- a/packages/gel/src/reflection/analyzeQuery.ts
+++ b/packages/gel/src/reflection/analyzeQuery.ts
@@ -169,6 +169,13 @@ export const defaultCodecGenerators: CodecGeneratorMap = new Map([
     if (codec.tsModule) {
       ctx.imports.add(codec.tsModule, codec.tsType);
     }
+    const isCustomScalar = !codec.typeName.startsWith("std::");
+
+    if (isCustomScalar) {
+      ctx.imports.add("gel", "ResolvedCodecType");
+      return `ResolvedCodecType<"${codec.typeName}", ${codec.tsType}>`;
+    }
+
     return codec.tsType;
   }),
   genDef(ObjectCodec, (codec, ctx) => {

--- a/packages/gel/src/reflection/analyzeQuery.ts
+++ b/packages/gel/src/reflection/analyzeQuery.ts
@@ -169,13 +169,6 @@ export const defaultCodecGenerators: CodecGeneratorMap = new Map([
     if (codec.tsModule) {
       ctx.imports.add(codec.tsModule, codec.tsType);
     }
-    const isCustomScalar = !codec.typeName.startsWith("std::");
-
-    if (isCustomScalar) {
-      ctx.imports.add("gel", "ResolvedCodecType");
-      return `ResolvedCodecType<"${codec.typeName}", ${codec.tsType}>`;
-    }
-
     return codec.tsType;
   }),
   genDef(ObjectCodec, (codec, ctx) => {

--- a/packages/generate/src/cli.ts
+++ b/packages/generate/src/cli.ts
@@ -206,6 +206,9 @@ const run = async () => {
       case "--use-http-client":
         options.useHttpClient = true;
         break;
+      case "--use-resolved-codec-type":
+        options.useResolvedCodecType = true;
+        break;
       case "--target": {
         if (
           generator === Generator.Interfaces ||

--- a/packages/generate/src/commandutil.ts
+++ b/packages/generate/src/commandutil.ts
@@ -16,6 +16,7 @@ export interface CommandOptions {
   forceOverwrite?: boolean;
   updateIgnoreFile?: boolean;
   useHttpClient?: boolean;
+  useResolvedCodecType?: boolean;
   future?: Partial<Record<keyof typeof defaultFutureFlags, boolean>>;
   patterns?: string[];
 }

--- a/packages/generate/src/queries.ts
+++ b/packages/generate/src/queries.ts
@@ -1,13 +1,6 @@
 import path from "node:path";
 import { promises as fs } from "node:fs";
-import {
-  $,
-  _CodecsRegistry,
-  _ScalarCodec,
-  systemUtils,
-  type Client,
-  type Executor,
-} from "gel";
+import { $, systemUtils, type Client, type Executor } from "gel";
 import { type CommandOptions } from "./commandutil";
 import { headerComment } from "./genutil";
 import type { Target } from "./genutil";
@@ -73,7 +66,7 @@ currently supported.`);
 
         try {
           const query = await readFileUtf8(p);
-          const types = await analyzeQuery(client, query, {
+          const types = await $.analyzeQuery(client, query, {
             useResolvedCodecType: params.options.useResolvedCodecType,
           });
           console.log(`   ${prettyPath}`);
@@ -129,7 +122,7 @@ currently supported.`);
     try {
       const query = await readFileUtf8(p);
       if (!query) return;
-      const types = await analyzeQuery(client, query, {
+      const types = await $.analyzeQuery(client, query, {
         useResolvedCodecType: params.options.useResolvedCodecType,
       });
       const files = generateFiles({
@@ -363,57 +356,4 @@ export class ImportMap extends Map<string, Set<string>> {
     }
     return out;
   }
-}
-
-const resolvedCodecTypeScalarTypeGenerator = $.defineCodecGeneratorTuple(
-  _ScalarCodec,
-  (codec, ctx) => {
-    if (codec.tsModule) {
-      ctx.imports.add(codec.tsModule, codec.tsType);
-    }
-    const isCustomScalar = !codec.typeName.startsWith("std::");
-    if (isCustomScalar) {
-      ctx.imports.add("gel", "ResolvedCodecType");
-      return `ResolvedCodecType<"${codec.typeName}", ${codec.tsType}>`;
-    }
-    return codec.tsType;
-  },
-);
-
-async function analyzeQuery(
-  client: Client,
-  query: string,
-  { useResolvedCodecType }: { useResolvedCodecType?: boolean } = {},
-): ReturnType<typeof $.analyzeQuery> {
-  const {
-    cardinality,
-    capabilities,
-    in: inCodec,
-    out: outCodec,
-  } = await client.describe(query);
-
-  const generators = new Map([
-    ...$.defaultCodecGenerators.entries(),
-    ...(useResolvedCodecType ? [resolvedCodecTypeScalarTypeGenerator] : []),
-  ]);
-
-  const args = $.generateTSTypeFromCodec(inCodec, $.Cardinality.One, {
-    optionalNulls: true,
-    readonly: true,
-    generators: generators,
-  });
-  const result = $.generateTSTypeFromCodec(outCodec, cardinality, {
-    generators: generators,
-  });
-
-  const imports = args.imports.merge(result.imports);
-  return {
-    result: result.type,
-    args: args.type,
-    cardinality,
-    capabilities,
-    query,
-    importMap: imports,
-    imports: imports.get("gel") ?? new Set(),
-  };
 }


### PR DESCRIPTION
## Why?

This PR adds the ability for users of the queries generator to override the TypeScript types of custom scalar variables via `OverrideCodecType`. The default scalar types are non-overrideable.

Example:

1. Set up a schema and a query:
`default.gel`:

```
module default {
  scalar type EvmAddress extending str {
    constraint expression on ( re_test(r'^0x[a-f0-9]{40}$', __subject__) );
  }

  scalar type HumanAge extending int16 {
    constraint max_value(120);
  }

  type User {
    required property primaryAddress -> EvmAddress {
      constraint exclusive;
    };
    required property firstName -> str;
    property username -> str {
      constraint exclusive;
    };
    property age -> HumanAge;
  }
}
```

`findUser.edgeql`:

```
select User {
  id,
  primaryAddress,
  username,
  age
} filter .id = <uuid>$id
```

2. Run `generate queries --target ts --use-resolved-codec-type`

3. Verify `findUser.query.ts` includes the overridable types:
```
export type FindUserReturns = {
  "primaryAddress": ResolvedCodecType<"EvmAddress", string>;
  "age": ResolvedCodecType<"HumanAge", number>;
  "id": string;
  "username": string | null;
} | null;

// Checking types -- should be types for base scalars
let result: NonNullable<FindUserReturns>;
result.username
    // ^? (property) "username": string | null

result.primaryAddress
    // ^? (property) "primaryAddress": string

result.age
    // ^? (property) "age": number
```

4. Add an override:
```typescript
declare module "gel" {
  export interface OverrideCodecType {
    "EvmAddress": `0x${string}`;
  }
}
```

5. Check types with overrides:

```
let result: NonNullable<FindUserReturns>;
result.username
    // ^? (property) "username": string | null

result.primaryAddress
    // ^? (property) "primaryAddress": `0x${string}`

result.age
    // ^? (property) "age": number
```


## How?

This PR attempts to implement this functionality in a backwards-compatible way, since `analyzeQuery` is technically a public API.[^1]


[^1]: Although it's only used in the queries generator within the repo, it's [mentioned in the README](https://github.com/geldata/gel-js/blob/6623d7ae97547fa11402e3a27c2d7afdf1212978/packages/generate/README.md?plain=1#L47-L63) as the primary API to build a custom generator, and it looks like [other projects](https://github.com/SeedCompany/cord-api-v3/blob/2aa9b360e0be5219f3563ced824c74825950b9aa/src/core/gel/generator/query-files.ts#L51) are using it.