### PR TITLE
fix: download CLI from packages.geldata.com

### DIFF
--- a/packages/gel/src/cli.mts
+++ b/packages/gel/src/cli.mts
@@ -15,7 +15,11 @@ const debug = Debug("gel:cli");
 
 const IS_TTY = process.stdout.isTTY;
 const SCRIPT_LOCATION = await fs.realpath(fileURLToPath(import.meta.url));
-const EDGEDB_PKG_ROOT = "https://packages.edgedb.com";
+// gel-init.sh defaults here; packages.edgedb.com no longer completes TLS.
+const EDGEDB_PKG_ROOT =
+  process.env.GEL_PKG_ROOT ??
+  process.env.EDGEDB_PKG_ROOT ??
+  "https://packages.geldata.com";
 const CACHE_DIR = envPaths("gel", { suffix: "" }).cache;
 const CACHED_CLI_PATH = path.join(CACHE_DIR, "/bin/gel");
 


### PR DESCRIPTION
`npx gel` downloads the CLI from a hardcoded `https://packages.edgedb.com`. That host no longer completes a TLS handshake (`curl` exit 35 / `Client network socket disconnected before secure TLS connection was established`), so the wrapper never installs the binary and any CI that relies on `npx gel project init` hangs.

`gel-init.sh` already defaults to `https://packages.geldata.com` via `EDGEDB_PKG_ROOT`. This matches that:

- Default package root is `https://packages.geldata.com`
- `GEL_PKG_ROOT` / `EDGEDB_PKG_ROOT` still override it

Confirmed: `packages.geldata.com/dist/x86_64-unknown-linux-musl/gel-cli` returns a valid ELF; `packages.edgedb.com` does not.
